### PR TITLE
Fix for multiserver docker-compose problems with hostnames.

### DIFF
--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -49,16 +49,16 @@ The different opencast nodes need a way to talk to each other, so that the
 relaying of the different workflow operations works correctly.
 
 The first (and usual) approach to that would be to use the hostnames of the
-containers for those URLs (i.e. `PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL`). If you
+containers for those URLs (e.g. `PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL`). If you
 do so, the links to the engage UI that will be generated from the admin UI will
 use those URLs, too. The engage UI as well will try to link the media with one
-of those provided URLs. If you know try to open those in a browser on your host,
+of those provided URLs. If you now try to open those in a browser on your host,
 it will fail to resolve the hostname. This is because the hostnames are only
-known to the containers themselves, internally, but not for your host, which is
+known to the containers themselves, internally, but not to your host, which is
 external to this environment.
 
 The implemented solution is to agree on a hostname or IP address which is
-available and resolvable both internally and externally. The complete
+reachable and resolvable both internally and externally. The complete
 communication between the nodes will then be routed via this point (hence the
 `EXPORT` on ports `8081` and `8082`). `docker-compose` does not provide a
 (known) way of doing this automatically, so the user needs to find such a

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -11,8 +11,8 @@ Usage:
 $ docker-compose -f docker-compose.allinone.hsql.yml up
 ```
 
-This setup starts a simple allinone opencast distribution with a Apache ActiveMQ
-Server and the internal HSQL Database.
+This setup starts a simple allinone Opencast distribution with an Apache
+ActiveMQ Server and the internal HSQL Database.
 
 ## AllInOne, MariaDB
 
@@ -21,20 +21,20 @@ Usage:
 $ docker-compose -f docker-compose.allinone.mariadb.yml up
 ```
 
-This setup starts a simple allinone opencast distribution with a Apache ActiveMQ
-server and a external MariaDB server.
+This setup starts a simple allinone Opencast distribution with an Apache
+ActiveMQ server and an external MariaDB server.
 
 ## Multiserver, MariaDB
 
-This setup is a little bit more complicated. Because the opencast nodes
-need to talk to each other, but also provide a externally known address for the
+This setup is a little bit more complicated. Because the Opencast nodes
+need to talk to each other, but also provide an externally known address for the
 engage interface, we first have to supply a valid hostname or IP address for the
 host on which those containers are running. A simple `localhost` or `127.0.0.1`
 will _not_ work.
 
 Usage:
 ```sh
-# set a environment variable with a valid IP address, e.g. 10.25.40.2
+# set an environment variable with a valid IP address, e.g. 10.25.40.2
 $ export HOSTIP=10.25.40.2
 # start the system with docker-compose, which will now know this IP address.
 $ docker-compose -f docker-compose.multiserver.mariadb.yml
@@ -45,7 +45,7 @@ $ docker-compose -f docker-compose.multiserver.mariadb.yml
 If you have the time and want to know what exactly happens in this example, let
 me explain:
 
-The different opencast nodes need a way to talk to each other, so that the
+The different Opencast nodes need a way to talk to each other, so that the
 relaying of the different workflow operations works correctly.
 
 The first (and usual) approach to that would be to use the hostnames of the
@@ -62,6 +62,6 @@ reachable and resolvable both internally and externally. The complete
 communication between the nodes will then be routed via this point (hence the
 `EXPORT` on ports `8081` and `8082`). `docker-compose` does not provide a
 (known) way of doing this automatically, so the user needs to find such a
-suitable hostname or IP address themselves and export it to a environment
+suitable hostname or IP address themselves and export it to an environment
 variable. This environment variable is then used in the docker-compose file to
 build valid URLs that fulfill the special requirements.

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -1,0 +1,41 @@
+# docker-compose files
+
+These docker-compose files can be used to quickly try out the Opencast system in
+different configurations. They are not designed to be production instances, but
+rather quick and dirty dev/demo instances.
+
+# AllInOne, HSQL
+
+Usage:
+```sh
+$ docker-compose -f docker-compose.allinone.hsql.yml up
+```
+
+This setup starts a simple allinone opencast distribution with a Apache ActiveMQ
+Server and the internal HSQL Database.
+
+# AllInOne, MariaDB
+
+Usage:
+```sh
+$ docker-compose -f docker-compose.allinone.mariadb.yml up
+```
+
+This setup starts a simple allinone opencast distribution with a Apache ActiveMQ
+server and a external MariaDB server.
+
+# Multiserver, MariaDB
+
+This setup is a little bit more complicated. Because the opencast nodes
+need to talk to each other, but also provide a externally known address for the
+engage interface, we first have to supply a valid hostname or IP address for the
+host on which those containers are running. A simple `localhost` or `127.0.0.1`
+will _not_ work.
+
+Usage:
+```sh
+# set a environment variable with a valid IP address, e.g. 10.25.40.2
+$ export HOSTIP=10.25.40.2
+# start the system with docker-compose, which will now know this IP address.
+$ docker-compose -f docker-compose.multiserver.mariadb.yml
+```

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -4,7 +4,7 @@ These docker-compose files can be used to quickly try out the Opencast system in
 different configurations. They are not designed to be production instances, but
 rather quick and dirty dev/demo instances.
 
-# AllInOne, HSQL
+## AllInOne, HSQL
 
 Usage:
 ```sh
@@ -14,7 +14,7 @@ $ docker-compose -f docker-compose.allinone.hsql.yml up
 This setup starts a simple allinone opencast distribution with a Apache ActiveMQ
 Server and the internal HSQL Database.
 
-# AllInOne, MariaDB
+## AllInOne, MariaDB
 
 Usage:
 ```sh
@@ -24,7 +24,7 @@ $ docker-compose -f docker-compose.allinone.mariadb.yml up
 This setup starts a simple allinone opencast distribution with a Apache ActiveMQ
 server and a external MariaDB server.
 
-# Multiserver, MariaDB
+## Multiserver, MariaDB
 
 This setup is a little bit more complicated. Because the opencast nodes
 need to talk to each other, but also provide a externally known address for the
@@ -39,3 +39,29 @@ $ export HOSTIP=10.25.40.2
 # start the system with docker-compose, which will now know this IP address.
 $ docker-compose -f docker-compose.multiserver.mariadb.yml
 ```
+
+### Wait, what? Why do I need to do that? Why will `localhost` not work?!
+
+If you have the time and want to know what exactly happens in this example, let
+me explain:
+
+The different opencast nodes need a way to talk to each other, so that the
+relaying of the different workflow operations works correctly.
+
+The first (and usual) approach to that would be to use the hostnames of the
+containers for those URLs (i.e. `PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL`). If you
+do so, the links to the engage UI that will be generated from the admin UI will
+use those URLs, too. The engage UI as well will try to link the media with one
+of those provided URLs. If you know try to open those in a browser on your host,
+it will fail to resolve the hostname. This is because the hostnames are only
+known to the containers themselves, internally, but not for your host, which is
+external to this environment.
+
+The implemented solution is to agree on a hostname or IP address which is
+available and resolvable both internally and externally. The complete
+communication between the nodes will then be routed via this point (hence the
+`EXPORT` on ports `8081` and `8082`). `docker-compose` does not provide a
+(known) way of doing this automatically, so the user needs to find such a
+suitable hostname or IP address themselves and export it to a environment
+variable. This environment variable is then used in the docker-compose file to
+build valid URLs that fulfill the special requirements.

--- a/docker-compose/docker-compose.multiserver.mariadb.yml
+++ b/docker-compose/docker-compose.multiserver.mariadb.yml
@@ -38,10 +38,10 @@ services:
     volumes:
       - ./assets/activemq.xml:/opt/activemq/conf/activemq.xml:ro
 
-  opencast_admin:
+  opencastadmin:
     image: learnweb/opencast:admin
     environment:
-      - ORG_OPENCASTPROJECT_SERVER_URL=http://localhost:8080
+      - ORG_OPENCASTPROJECT_SERVER_URL=http://${HOSTIP}:8080
       - ORG_OPENCASTPROJECT_SECURITY_ADMIN_USER=admin
       - ORG_OPENCASTPROJECT_SECURITY_ADMIN_PASS=opencast
       - ORG_OPENCASTPROJECT_SECURITY_DIGEST_USER=opencast_system_account
@@ -50,8 +50,8 @@ services:
       - ORG_OPENCASTPROJECT_DB_JDBC_URL=jdbc:mysql://mariadb/opencast
       - ORG_OPENCASTPROJECT_DB_JDBC_USER=opencast
       - ORG_OPENCASTPROJECT_DB_JDBC_PASS=opencast
-      - PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL=http://localhost:8080
-      - PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL=http://localhost:8081
+      - PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL=http://${HOSTIP}:8080
+      - PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL=http://${HOSTIP}:8081
       - ACTIVEMQ_BROKER_URL=failover://tcp://activemq:61616
       - ACTIVEMQ_BROKER_USERNAME=admin
       - ACTIVEMQ_BROKER_PASSWORD=password
@@ -60,10 +60,10 @@ services:
     volumes:
       - data:/data/opencast
 
-  opencast_presentation:
+  opencastpresentation:
     image: learnweb/opencast:presentation
     environment:
-      - ORG_OPENCASTPROJECT_SERVER_URL=http://localhost:8081
+      - ORG_OPENCASTPROJECT_SERVER_URL=http://${HOSTIP}:8081
       - ORG_OPENCASTPROJECT_SECURITY_ADMIN_USER=admin
       - ORG_OPENCASTPROJECT_SECURITY_ADMIN_PASS=opencast
       - ORG_OPENCASTPROJECT_SECURITY_DIGEST_USER=opencast_system_account
@@ -72,8 +72,8 @@ services:
       - ORG_OPENCASTPROJECT_DB_JDBC_URL=jdbc:mysql://mariadb/opencast
       - ORG_OPENCASTPROJECT_DB_JDBC_USER=opencast
       - ORG_OPENCASTPROJECT_DB_JDBC_PASS=opencast
-      - PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL=http://localhost:8080
-      - PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL=http://localhost:8081
+      - PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL=http://${HOSTIP}:8080
+      - PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL=http://${HOSTIP}:8081
       - ACTIVEMQ_BROKER_URL=failover://tcp://activemq:61616
       - ACTIVEMQ_BROKER_USERNAME=admin
       - ACTIVEMQ_BROKER_PASSWORD=password
@@ -82,10 +82,10 @@ services:
     volumes:
       - data:/data/opencast
 
-  opencast_worker:
+  opencastworker:
     image: learnweb/opencast:worker
     environment:
-      - ORG_OPENCASTPROJECT_SERVER_URL=http://localhost:8082
+      - ORG_OPENCASTPROJECT_SERVER_URL=http://${HOSTIP}:8082
       - ORG_OPENCASTPROJECT_SECURITY_ADMIN_USER=admin
       - ORG_OPENCASTPROJECT_SECURITY_ADMIN_PASS=opencast
       - ORG_OPENCASTPROJECT_SECURITY_DIGEST_USER=opencast_system_account
@@ -94,8 +94,8 @@ services:
       - ORG_OPENCASTPROJECT_DB_JDBC_URL=jdbc:mysql://mariadb/opencast
       - ORG_OPENCASTPROJECT_DB_JDBC_USER=opencast
       - ORG_OPENCASTPROJECT_DB_JDBC_PASS=opencast
-      - PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL=http://localhost:8080
-      - PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL=http://localhost:8081
+      - PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL=http://${HOSTIP}:8080
+      - PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL=http://${HOSTIP}:8081
       - ACTIVEMQ_BROKER_URL=failover://tcp://activemq:61616
       - ACTIVEMQ_BROKER_USERNAME=admin
       - ACTIVEMQ_BROKER_PASSWORD=password


### PR DESCRIPTION
I've created a workaround that will allow you to start a multiserver setup with docker-compose without too much work. A detailed explanation why it is needed and how it works can be found in `docker-compose/README.md`.