### PR TITLE
Change base image to java:8-jdk-alpine

### DIFF
--- a/Dockerfiles/admin/Dockerfile
+++ b/Dockerfiles/admin/Dockerfile
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM maven:3-jdk-8
-MAINTAINER WWU eLectures team <dev.learnweb@uni-muenster.de>
+FROM java:8-jdk-alpine
+MAINTAINER WWU eLectures team <electures.dev@uni-muenster.de>
 
 ENV OPENCAST_VERSION="2.1.1" \
     OPENCAST_DISTRIBUTION="admin" \
@@ -24,46 +24,133 @@ ENV OPENCAST_VERSION="2.1.1" \
     OPENCAST_USER="opencast" \
     OPENCAST_GROUP="opencast" \
     OPENCAST_UID="800" \
-    OPENCAST_GID="800"
+    OPENCAST_GID="800" \
+    \
+    TESSERACT_BASE_URL="https://github.com/tesseract-ocr/tessdata/raw/master" \
+    HUNSPELL_BASE_URL="http://download.services.openoffice.org/contrib/dictionaries" \
+    TESSERACT_LANG="\
+cb7eb42a7e972cec7ef904fe81825d7b547c46df684c814fdb11a930b13bca3a deu.traineddata\n\
+64adf2cc0b2a6705368aa357224d1a6739035d5fe892cd0cc457016df5b4280f eng.cube.bigrams\n\
+2b229895623934b493fe69c51fcc387295d91af8b4e43cc51748b3d269a95eed eng.cube.fold\n\
+a6f769245b0a55f42a3ce157cd19d96828483c3384c6483433ed83579ea16e36 eng.cube.lm\n\
+8f345f1c19772dd71a5214bc94175ccf647c003ab77e4143fde48f11bf3cb0ef eng.cube.nn\n\
+c2aa2854951bd823d89cc86d53a6d9712a6a885de6fbaf650ff3df48bfed85d7 eng.cube.params\n\
+e5f95de7e2754eb2df03451885277ca4573b3770816043ae2e2f09d1f7232604 eng.cube.size\n\
+8d612bef20ae3052fce0b8650575a80d87c94d772ec6d1f0c6a1ad591586ea44 eng.cube.word-freq\n\
+196bedc8a5bc8c30361c2c9518f648b45b498759cb6041827ff6fbfb8da2a8d1 eng.tesseract_cube.nn\n\
+c0515c9f1e0c79e1069fcc05c2b2f6a6841fb5e1082d695db160333c1154f06d eng.traineddata\
+    " \
+    HUNSPELL_LANG="\
+2478723ab67dd801ec6add11b1af9d32665e7859a1cb00c95bfc2b618584a802 de_AT.zip\n\
+c30bb085ba0a3d22a23aef51f4dd94ae9ae0cc811c0590ebf3713a93b209d823 de_CH.zip\n\
+220e01c3137000305247336d8d10cd550bda3990fb10e50b31633947969a34b8 de_DE_comb.zip\n\
+22e217a631977d7b377f8dd22d2bbacd2d36b32765ce13f3474b03a4a97dd700 en_AU.zip\n\
+31fac12a1b520cde686f328d3fa7560f6eba772cddc872197ff842c57a0dc1ea en_CA.zip\n\
+5869d8bd80eb2eb328ebe36b356348de4ae2acb1db6df39d1717d33f89f63728 en_GB.zip\n\
+6cc717b4de43240595662a2deef5447b06062e82380f5647196f07c9089284fa en_NZ.zip\n\
+9227f658f182c9cece797352f041a888134765c11bffc91951c010a73187baea en_US.zip\n\
+090285b721dcaabff51b467123f82a181a6904d187c90bda812c6e5f365ff19a en_ZA.zip\
+    "
 ENV OPENCAST_SCRIPTS="${OPENCAST_HOME}/docker/scripts" \
     OPENCAST_CONFIG="${OPENCAST_HOME}/etc" \
-    OPENCAST_URL="https://bitbucket.org/opencast-community/matterhorn/get/${OPENCAST_VERSION}.tar.bz2"
+    OPENCAST_URL="https://bitbucket.org/opencast-community/matterhorn/get/${OPENCAST_VERSION}.tar.gz"
 
-# Dependencies
-#   - cURL and bzip2
-#   - FFmpeg
-#   - MediaInfo
-#   - Sound eXchange (SoX)
-#   - Tesseract Open Source OCR Engine
-#   -   - english
-#   -   - german
-#   - TODO: which languages to include?
-#   - Hunspell
-#   -   - english
-#   -   - german
-#   - TODO: which languages to include?
-RUN apt-get update \
- && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      curl bzip2 \
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
+ && apk add --no-cache --virtual .build-deps \
+      tar gzip \
+      git \
+      make gcc g++ binutils-gold \
+      maven \
+      python \
+      nodejs \
+      \
+      # TODO: for tesseract; remove once package is updated
+      automake autoconf libtool \
+  \
+  # Install dependencies
+  #   - FFmpeg
+  #   - Sound eXchange (SoX)
+  #   - Tesseract Open Source OCR Engine
+  #   - Hunspell
+ && apk add --no-cache --virtual .run-deps \
       ffmpeg \
-      mediainfo \
-      sox libsox-fmt-all \
-      tesseract-ocr tesseract-ocr-eng tesseract-ocr-deu \
-      hunspell hunspell-en-us hunspell-de-de \
- && rm -rf /var/lib/apt/lists/*
-
-# Opencast
-RUN mkdir -p "${OPENCAST_SRC}" "${OPENCAST_HOME}" "${OPENCAST_DATA}" "${OPENCAST_SCRIPTS}" \
- && groupadd -r "${OPENCAST_GROUP}" -g "${OPENCAST_GID}" \
- && useradd -r -g "${OPENCAST_GROUP}" -d "${OPENCAST_HOME}" -u "${OPENCAST_UID}" "${OPENCAST_USER}" \
- && chown "${OPENCAST_USER}":"${OPENCAST_GROUP}" "${OPENCAST_SRC}" "${OPENCAST_HOME}" "${OPENCAST_DATA}"
-
-RUN cd "${OPENCAST_SRC}" \
- && curl -sSL "${OPENCAST_URL}" | tar -xj --strip 1 -C . \
- && mvn --quiet --batch-mode clean install -DskipTests=true -Dcheckstyle.skip=true \
- && tar -xzf "build/opencast-dist-${OPENCAST_DISTRIBUTION}-${OPENCAST_VERSION}.tar.gz" --strip 1 -C "${OPENCAST_HOME}" \
- && chown -R "${OPENCAST_USER}":"${OPENCAST_GROUP}" "${OPENCAST_HOME}" \
- && rm -rf "${OPENCAST_SRC}" /tmp/* ~/.npm ~/.node-gyp
+      sox \
+      hunspell \
+      \
+      # TODO: for tesseract; remove once package is updated
+      libjpeg-turbo-dev tiff-dev libpng-dev zlib-dev giflib-dev libwebp-dev \
+  \
+  # TODO: compile tesseract; remove once package is updated
+ && LEPTONICA_VERSION=1.73 \
+ && TESSERACT_VERSION=3.04.01 \
+ && mkdir -p /tmp/compile/leptonica /tmp/compile/tesseract \
+ && cd /tmp/compile \
+ && wget -q -O - "http://www.leptonica.com/source/leptonica-${LEPTONICA_VERSION}.tar.gz" | tar -xz --strip 1 -C leptonica \
+ && wget -q -O - "https://github.com/tesseract-ocr/tesseract/archive/${TESSERACT_VERSION}.tar.gz" | tar -xz --strip 1 -C tesseract \
+ && cd leptonica \
+ && ./configure \
+     --prefix=/usr \
+     --sysconfdir=/etc \
+     --mandir=/usr/share/man \
+     --infodir=/usr/share/info \
+     --localstatedir=/var \
+ && make \
+ && make install \
+ && cd ../tesseract/ \
+ && ./autogen.sh \
+ && ./configure \
+   --prefix=/usr \
+   --sysconfdir=/etc \
+   --mandir=/usr/share/man \
+   --infodir=/usr/share/info \
+   --localstatedir=/var \
+   --disable-static \
+   --disable-graphics \
+ && make \
+ && make install \
+  \
+  # Install languag files for tesseract and hunspell
+ && mkdir -p /tmp/tesseract /tmp/hunspell /usr/share/hunspell /usr/share/tesseract \
+ && echo -e ${TESSERACT_LANG} > /tmp/tesseract-sha256sum.txt \
+ && echo -e ${HUNSPELL_LANG} > /tmp/hunspell-sha256sum.txt \
+  \
+  # TODO: How to output with two spaces?
+ && sed -i "s/ /  /g" /tmp/tesseract-sha256sum.txt /tmp/hunspell-sha256sum.txt \
+ && cd /tmp/tesseract \
+ && for file in $(awk '{print $2}' /tmp/tesseract-sha256sum.txt); do \
+      wget -O "${file}" "${TESSERACT_BASE_URL}/${file}"; \
+      grep "${file}" /tmp/tesseract-sha256sum.txt | sha256sum -c -; \
+      cp "${file}" /usr/share/tesseract; \
+    done \
+ && cd /tmp/hunspell \
+ && for file in $(awk '{print $2}' /tmp/hunspell-sha256sum.txt); do \
+      wget -O "${file}" "${HUNSPELL_BASE_URL}/${file}"; \
+      grep "${file}" /tmp/hunspell-sha256sum.txt | sha256sum -c -; \
+      unzip "/tmp/hunspell/${file}"; \
+    done \
+ && cp *.aff *.dic /usr/share/hunspell \
+  \
+  # Compile frontend assets manually as the bundeled node does not run on Alpine
+ && mkdir -p "${OPENCAST_SRC}" "${OPENCAST_HOME}" "${OPENCAST_DATA}" "${OPENCAST_SCRIPTS}" \
+ && wget -O - "${OPENCAST_URL}" | tar -xz --strip 1 -C "${OPENCAST_SRC}" \
+ && cd "${OPENCAST_SRC}/modules/matterhorn-admin-ui-ng" \
+ && sed -i 's/"grunt-sass":.*/"grunt-sass": "^1.2.0",/g' package.json \
+ && npm install -g npm@2 \
+ && npm install -g grunt \
+ && npm install \
+ && grunt build --no-color --skipTests=true \
+  \
+  # Compile and install Opencast
+ && cd "${OPENCAST_SRC}" \
+ && mvn --quiet --batch-mode install -P '!frontend' -DskipTests=true -Dcheckstyle.skip=true \
+ && tar -xzf build/opencast-dist-${OPENCAST_DISTRIBUTION}-*.tar.gz --strip 1 -C "${OPENCAST_HOME}" \
+ && addgroup -S -g "${OPENCAST_GID}" "${OPENCAST_GROUP}" \
+ && adduser -S -D -H -G "${OPENCAST_GROUP}" -h "${OPENCAST_HOME}" -u "${OPENCAST_UID}" "${OPENCAST_USER}" \
+ && chown -R "${OPENCAST_USER}":"${OPENCAST_GROUP}" "${OPENCAST_HOME}" "${OPENCAST_DATA}" \
+  \
+  # Cleanup
+ && apk del .build-deps \
+ && rm -rf "${OPENCAST_SRC}" /tmp/* ~/.m2 ~/.npm ~/.node-gyp /usr/lib/node_modules
 
 COPY assets/scripts/* "${OPENCAST_SCRIPTS}/"
 COPY assets/etc/* "${OPENCAST_CONFIG}/"

--- a/Dockerfiles/admin/assets/docker-entrypoint.sh
+++ b/Dockerfiles/admin/assets/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright 2016 The WWU eLectures Team All rights reserved.
 #
@@ -16,63 +16,71 @@
 
 set -e
 
-source "${OPENCAST_SCRIPTS}/helper.sh"
-source "${OPENCAST_SCRIPTS}/opencast.sh"
-source "${OPENCAST_SCRIPTS}/activemq.sh"
-source "${OPENCAST_SCRIPTS}/db.sh"
-source "${OPENCAST_SCRIPTS}/hsql.sh"
-source "${OPENCAST_SCRIPTS}/jdbc.sh"
-source "${OPENCAST_SCRIPTS}/mysql.sh"
+# shellcheck source=./scripts/helper.sh
+. "${OPENCAST_SCRIPTS}/helper.sh"
+# shellcheck source=./scripts/opencast.sh
+. "${OPENCAST_SCRIPTS}/opencast.sh"
+# shellcheck source=./scripts/activemq.sh
+. "${OPENCAST_SCRIPTS}/activemq.sh"
+# shellcheck source=./scripts/db.sh
+. "${OPENCAST_SCRIPTS}/db.sh"
+# shellcheck source=./scripts/hsql.sh
+. "${OPENCAST_SCRIPTS}/hsql.sh"
+# shellcheck source=./scripts/jdbc.sh
+. "${OPENCAST_SCRIPTS}/jdbc.sh"
+# shellcheck source=./scripts/mysql.sh
+. "${OPENCAST_SCRIPTS}/mysql.sh"
 
-Opencast::Main::Check() {
-  echo "Run Opencast::Main::Check"
 
-  Opencast::Opencast::Check
-  Opencast::ActiveMQ::Check
-  Opencast::DB::Check
+opencast_main_check() {
+  echo "Run opencast_main_check"
+
+  opencast_opencast_check
+  opencast_activemq_check
+  opencast_db_check
 }
 
-Opencast::Main::Configure() {
-  echo "Run Opencast::Main::Configure"
+opencast_main_configure() {
+  echo "Run opencast_main_configure"
 
-  Opencast::Opencast::Configure
-  Opencast::ActiveMQ::Configure
-  Opencast::DB::Configure
+  opencast_opencast_configure
+  opencast_activemq_configure
+  opencast_db_configure
 }
 
-Opencast::Main::Init() {
-  echo "Run Opencast::Main::Init"
+opencast_main_init() {
+  echo "Run opencast_main_init"
 
-  if Opencast::Helper::CustomConfig; then
+  if opencast_helper_customconfig; then
     echo "Found custom config in ${OPENCAST_CUSTOM_CONFIG}"
-    echo "Run Opencast::Helper::CopyCustomConfig"
-    Opencast::Helper::CopyCustomConfig
+    echo "Run opencast_helper_copycustomconfig"
+    opencast_helper_copycustomconfig
   else
     echo "No custom config found"
-    Opencast::Main::Check
-    Opencast::Main::Configure
+    opencast_main_check
+    opencast_main_configure
   fi
 }
 
-Opencast::Main::Start() {
-  echo "Run Opencast::Main::Start"
+opencast_main_start() {
+  echo "Run opencast_main_start"
   exec "bin/start-opencast" "server"
 }
 
 case ${1} in
   app:init)
-    Opencast::Main::Init
+    opencast_main_init
     ;;
   app:start)
-    Opencast::Main::Init
-    Opencast::DB::TryToConnect
-    Opencast::Main::Start
+    opencast_main_init
+    opencast_db_trytoconnect
+    opencast_main_start
     ;;
   app:print:activemq.xml)
-    Opencast::ActiveMQ::PrintActivemq.xml
+    opencast_activemq_printactivemqxml
     ;;
   app:print:dll)
-    Opencast::DB::PrintDDL
+    opencast_db_print_ddl
     ;;
   app:help)
     echo "Usage:"

--- a/Dockerfiles/admin/assets/scripts/activemq.sh
+++ b/Dockerfiles/admin/assets/scripts/activemq.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright 2016 The WWU eLectures Team All rights reserved.
 #
@@ -16,25 +16,25 @@
 
 set -e
 
-Opencast::ActiveMQ::Check() {
-  echo "Run Opencast::ActiveMQ::Check"
+opencast_activemq_check() {
+  echo "Run opencast_activemq_check"
 
-  Opencast::Helper::CheckForVariables \
+  opencast_helper_checkforvariables \
     "ACTIVEMQ_BROKER_URL" \
     "ACTIVEMQ_BROKER_USERNAME" \
     "ACTIVEMQ_BROKER_PASSWORD"
 }
 
-Opencast::ActiveMQ::Configure() {
-  echo "Run Opencast::ActiveMQ::Configure"
+opencast_activemq_configure() {
+  echo "Run opencast_activemq_configure"
 
-  Opencast::Helper::ReplaceInfile "etc/custom.properties" \
+  opencast_helper_replaceinfile "etc/custom.properties" \
     "ACTIVEMQ_BROKER_URL" \
     "ACTIVEMQ_BROKER_USERNAME" \
     "ACTIVEMQ_BROKER_PASSWORD"
 }
 
-Opencast::ActiveMQ::PrintActivemq.xml() {
+opencast_activemq_printactivemqxml() {
   # TODO: read env variables and add config for jaasAuthenticationPlugin
   cat /opencast/docs/scripts/activemq/activemq.xml
 }

--- a/Dockerfiles/admin/assets/scripts/db.sh
+++ b/Dockerfiles/admin/assets/scripts/db.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright 2016 The WWU eLectures Team All rights reserved.
 #
@@ -19,16 +19,16 @@ set -e
 ORG_OPENCASTPROJECT_DB_VENDOR="${ORG_OPENCASTPROJECT_DB_VENDOR:-HSQL}"
 NUMER_OF_TIMES_TRYING_TO_CONNECT_TO_DB="${NUMER_OF_TIMES_TRYING_TO_CONNECT_TO_DB:-25}"
 
-Opencast::DB::Check() {
-  echo "Run Opencast::DB::Check"
+opencast_db_check() {
+  echo "Run opencast_db_check"
 
   case "$ORG_OPENCASTPROJECT_DB_VENDOR" in
     HSQL)
-      Opencast::HSQL::Check
+      opencast_hsql_check
       ;;
     MySQL)
-      Opencast::MySQL::Check
-      Opencast::JDBC::Check
+      opencast_mysql_check
+      opencast_jdbc_check
       ;;
     *)
       echo >&2 "error: ${ORG_OPENCASTPROJECT_DB_VENDOR} is currently not supported as database vendor"
@@ -37,16 +37,16 @@ Opencast::DB::Check() {
   esac
 }
 
-Opencast::DB::Configure() {
-  echo "Run Opencast::DB::Configure"
+opencast_db_configure() {
+  echo "Run opencast_db_configure"
 
   case "$ORG_OPENCASTPROJECT_DB_VENDOR" in
     HSQL)
-      Opencast::HSQL::Configure
+      opencast_hsql_configure
       ;;
     MySQL)
-      Opencast::MySQL::Configure
-      Opencast::JDBC::Configure
+      opencast_mysql_configure
+      opencast_jdbc_configure
       ;;
     *)
       echo >&2 "error: ${ORG_OPENCASTPROJECT_DB_VENDOR} is currently not supported as database vendor"
@@ -55,15 +55,15 @@ Opencast::DB::Configure() {
   esac
 }
 
-Opencast::DB::TryToConnect() {
-  echo "Run Opencast::DB::TryToConnect"
+opencast_db_trytoconnect() {
+  echo "Run opencast_db_trytoconnect"
 
   case "$ORG_OPENCASTPROJECT_DB_VENDOR" in
     HSQL)
-      Opencast::HSQL::TryToConnect
+      opencast_hsql_trytoconnect
       ;;
     MySQL)
-      Opencast::JDBC::TryToConnect
+      opencast_jdbc_trytoconnect
       ;;
     *)
       echo >&2 "error: ${ORG_OPENCASTPROJECT_DB_VENDOR} is currently not supported as database vendor"
@@ -72,15 +72,15 @@ Opencast::DB::TryToConnect() {
   esac
 }
 
-Opencast::DB::PrintDDL() {
+opencast_db_printddl() {
   echo "-- Created with Opencast version ${OPENCAST_VERSION}"
   echo
   case "$ORG_OPENCASTPROJECT_DB_VENDOR" in
     HSQL)
-      Opencast::HSQL::PrintDDL
+      opencast_hsql_printddl
       ;;
     MySQL)
-      Opencast::MySQL::PrintDDL
+      opencast_mysql_printddl
       ;;
     *)
       echo >&2 "error: ${ORG_OPENCASTPROJECT_DB_VENDOR} is currently not supported as database vendor"

--- a/Dockerfiles/admin/assets/scripts/helper.sh
+++ b/Dockerfiles/admin/assets/scripts/helper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright 2016 The WWU eLectures Team All rights reserved.
 #
@@ -16,34 +16,36 @@
 
 set -e
 
-Opencast::Helper::Dist::admin() {
+opencast_helper_dist_admin() {
   test "${OPENCAST_DISTRIBUTION}" = "admin"
 }
 
-Opencast::Helper::Dist::allinone() {
+opencast_helper_dist_allinone() {
   test "${OPENCAST_DISTRIBUTION}" = "allinone"
 }
 
-Opencast::Helper::Dist::presentation() {
+opencast_helper_dist_presentation() {
   test "${OPENCAST_DISTRIBUTION}" = "presentation"
 }
 
-Opencast::Helper::Dist::worker() {
+opencast_helper_dist_worker() {
   test "${OPENCAST_DISTRIBUTION}" = "worker"
 }
 
-Opencast::Helper::CustomConfig() {
+opencast_helper_customconfig() {
   test -d "${OPENCAST_CUSTOM_CONFIG}"
 }
 
-Opencast::Helper::CopyCustomConfig() {
+opencast_helper_copycustomconfig() {
   rm -rf "${OPENCAST_CONFIG}"
   cp -r "${OPENCAST_CUSTOM_CONFIG}" "${OPENCAST_CONFIG}"
 }
 
-Opencast::Helper::CheckForVariables() {
+opencast_helper_checkforvariables() {
   for var in "$@"; do
-    if test -z "${!var}"; then
+    eval exp_var="\$${var}"
+    # shellcheck disable=SC2154
+    if test -z "${exp_var}"; then
       echo >&2 "error: missing Opencast ${var} environment variables"
       echo >&2 "  Did you forget to -e ${var}=value ?"
       exit 1
@@ -52,17 +54,18 @@ Opencast::Helper::CheckForVariables() {
 }
 
 # Replaces {{$2...}} with $!2... in file $1
-Opencast::Helper::ReplaceInfile() {
-  local file="$1"
+opencast_helper_replaceinfile() {
+  file="$1"
   shift
   for var in "$@"; do
-    sed -ri "s/[{]{2}${var}[}]{2}/$( echo ${!var} | sed -e 's/[\/&]/\\&/g' )/g" "${file}"
+    eval exp_var="\$${var}"
+    sed -ri "s/[{]{2}${var}[}]{2}/$( echo ${exp_var} | sed -e 's/[\/&]/\\&/g' )/g" "${file}"
   done
 }
 
 # Deletes lines containing {{$2...}} in file $1
-Opencast::Helper::DeleteInfile() {
-  local file="$1"
+opencast_helper_deleteinfile() {
+  file="$1"
   shift
   for var in "$@"; do
     sed -ri "/[{]{2}${var}[}]{2}/d" "${file}"

--- a/Dockerfiles/admin/assets/scripts/hsql.sh
+++ b/Dockerfiles/admin/assets/scripts/hsql.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright 2016 The WWU eLectures Team All rights reserved.
 #
@@ -16,30 +16,30 @@
 
 set -e
 
-Opencast::HSQL::Check() {
-  echo "Run Opencast::HSQL::Check"
+opencast_hsql_check() {
+  echo "Run opencast_hsql_check"
 
-  ORG_OPENCASTPROJECT_DB_DDL_GENERATION="true"
+  export ORG_OPENCASTPROJECT_DB_DDL_GENERATION="true"
 }
 
-Opencast::HSQL::Configure() {
-  echo "Run Opencast::HSQL::Configure"
+opencast_hsql_configure() {
+  echo "Run opencast_hsql_configure"
 
-  Opencast::Helper::DeleteInfile "etc/custom.properties" \
+  opencast_helper_deleteinfile "etc/custom.properties" \
     "ORG_OPENCASTPROJECT_DB_VENDOR" \
     "ORG_OPENCASTPROJECT_DB_JDBC_DRIVER" \
     "ORG_OPENCASTPROJECT_DB_JDBC_URL" \
     "ORG_OPENCASTPROJECT_DB_JDBC_USER" \
     "ORG_OPENCASTPROJECT_DB_JDBC_PASS"
 
-  Opencast::Helper::ReplaceInfile "etc/custom.properties" \
+  opencast_helper_replaceinfile "etc/custom.properties" \
     "ORG_OPENCASTPROJECT_DB_DDL_GENERATION"
 }
 
-Opencast::HSQL::TryToConnect() {
-  echo "Run Opencast::HSQL::TryToConnect"
+opencast_hsql_trytoconnect() {
+  echo "Run opencast_hsql_trytoconnect"
 }
 
-Opencast::HSQL::PrintDDL() {
+opencast_hsql_printddl() {
   echo "-- Database for HSQL is created automatically"
 }

--- a/Dockerfiles/admin/assets/scripts/jdbc.sh
+++ b/Dockerfiles/admin/assets/scripts/jdbc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright 2016 The WWU eLectures Team All rights reserved.
 #
@@ -16,12 +16,12 @@
 
 set -e
 
-Opencast::JDBC::Check() {
-  echo "Run Opencast::JDBC::Check"
+opencast_jdbc_check() {
+  echo "Run opencast_jdbc_check"
 
   ORG_OPENCASTPROJECT_DB_DDL_GENERATION="${ORG_OPENCASTPROJECT_DB_DDL_GENERATION:-false}"
 
-  Opencast::Helper::CheckForVariables \
+  opencast_helper_checkforvariables \
     "ORG_OPENCASTPROJECT_DB_DDL_GENERATION" \
     "ORG_OPENCASTPROJECT_DB_JDBC_DRIVER" \
     "ORG_OPENCASTPROJECT_DB_JDBC_URL" \
@@ -29,10 +29,10 @@ Opencast::JDBC::Check() {
     "ORG_OPENCASTPROJECT_DB_JDBC_PASS"
 }
 
-Opencast::JDBC::Configure() {
-  echo "Run Opencast::JDBC::Configure"
+opencast_jdbc_configure() {
+  echo "Run opencast_jdbc_configure"
 
-  Opencast::Helper::ReplaceInfile "etc/custom.properties" \
+  opencast_helper_replaceinfile "etc/custom.properties" \
     "ORG_OPENCASTPROJECT_DB_VENDOR" \
     "ORG_OPENCASTPROJECT_DB_DDL_GENERATION" \
     "ORG_OPENCASTPROJECT_DB_JDBC_DRIVER" \
@@ -41,8 +41,8 @@ Opencast::JDBC::Configure() {
     "ORG_OPENCASTPROJECT_DB_JDBC_PASS"
 }
 
-Opencast::JDBC::TryToConnect() {
-  echo "Run Opencast::JDBC::TryToConnect"
+opencast_jdbc_trytoconnect() {
+  echo "Run opencast_jdbc_trytoconnect"
 
   driver=$(awk -F "=" '/org\.opencastproject\.db\.jdbc\.driver/ {print $2}' etc/custom.properties | tr -d ' ')
   url=$(awk -F "=" '/org\.opencastproject\.db\.jdbc\.url/ {print $2}' etc/custom.properties | tr -d ' ')

--- a/Dockerfiles/admin/assets/scripts/mysql.sh
+++ b/Dockerfiles/admin/assets/scripts/mysql.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright 2016 The WWU eLectures Team All rights reserved.
 #
@@ -16,15 +16,15 @@
 
 set -e
 
-Opencast::MySQL::Check() {
-  echo "Run Opencast::MySQL::Check"
-  ORG_OPENCASTPROJECT_DB_JDBC_DRIVER="com.mysql.jdbc.Driver"
+opencast_mysql_check() {
+  echo "Run opencast_mysql_check"
+  export ORG_OPENCASTPROJECT_DB_JDBC_DRIVER="com.mysql.jdbc.Driver"
 }
 
-Opencast::MySQL::Configure() {
-  echo "Run Opencast::MySQL::Configure"
+opencast_mysql_configure() {
+  echo "Run opencast_mysql_configure"
 }
 
-Opencast::MySQL::PrintDDL() {
+opencast_mysql_printddl() {
   cat /opencast/docs/scripts/ddl/mysql5.sql
 }

--- a/Dockerfiles/admin/assets/scripts/opencast.sh
+++ b/Dockerfiles/admin/assets/scripts/opencast.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright 2016 The WWU eLectures Team All rights reserved.
 #
@@ -19,15 +19,17 @@ set -e
 ORG_OPENCASTPROJECT_ADMIN_EMAIL="${ORG_OPENCASTPROJECT_ADMIN_EMAIL:-admin@localhost}"
 ORG_OPENCASTPROJECT_DOWNLOAD_URL="${ORG_OPENCASTPROJECT_DOWNLOAD_URL:-\$\{org.opencastproject.server.url\}/static}"
 
-if Opencast::Helper::Dist::allinone; then
-  ORG_OPENCASTPROJECT_FILE_REPO_URL='${org.opencastproject.server.url}'
+if opencast_helper_dist_allinone; then
+  # shellcheck disable=SC2016
+  export ORG_OPENCASTPROJECT_FILE_REPO_URL='${org.opencastproject.server.url}'
 else
-  ORG_OPENCASTPROJECT_FILE_REPO_URL='${org.opencastproject.admin.ui.url}'
+  # shellcheck disable=SC2016
+  export ORG_OPENCASTPROJECT_FILE_REPO_URL='${org.opencastproject.admin.ui.url}'
 fi
 
-Opencast::Opencast::Check() {
-  echo "Run Opencast::Opencast::Check"
-  Opencast::Helper::CheckForVariables \
+opencast_opencast_check() {
+  echo "Run opencast_opencast_check"
+  opencast_helper_checkforvariables \
     "ORG_OPENCASTPROJECT_SERVER_URL" \
     "ORG_OPENCASTPROJECT_SECURITY_ADMIN_USER" \
     "ORG_OPENCASTPROJECT_SECURITY_ADMIN_PASS" \
@@ -35,16 +37,16 @@ Opencast::Opencast::Check() {
     "ORG_OPENCASTPROJECT_SECURITY_DIGEST_PASS" \
     "ORG_OPENCASTPROJECT_FILE_REPO_URL"
 
-  if ! Opencast::Helper::Dist::allinone; then
-    Opencast::Helper::CheckForVariables \
+  if ! opencast_helper_dist_allinone; then
+    opencast_helper_checkforvariables \
       "PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL" \
       "PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL"
   fi
 }
 
-Opencast::Opencast::Configure() {
-  echo "Run Opencast::Opencast::Configure"
-  Opencast::Helper::ReplaceInfile "etc/custom.properties" \
+opencast_opencast_configure() {
+  echo "Run opencast_opencast_configure"
+  opencast_helper_replaceinfile "etc/custom.properties" \
     "ORG_OPENCASTPROJECT_ADMIN_EMAIL" \
     "ORG_OPENCASTPROJECT_SERVER_URL" \
     "ORG_OPENCASTPROJECT_SECURITY_ADMIN_USER" \
@@ -54,8 +56,8 @@ Opencast::Opencast::Configure() {
     "ORG_OPENCASTPROJECT_FILE_REPO_URL" \
     "ORG_OPENCASTPROJECT_DOWNLOAD_URL"
 
-  if ! Opencast::Helper::Dist::allinone; then
-    Opencast::Helper::ReplaceInfile "etc/org.opencastproject.organization-mh_default_org.cfg" \
+  if ! opencast_helper_dist_allinone; then
+    opencast_helper_replaceinfile "etc/org.opencastproject.organization-mh_default_org.cfg" \
       "PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL" \
       "PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL"
   fi

--- a/Dockerfiles/allinone/Dockerfile
+++ b/Dockerfiles/allinone/Dockerfile
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM maven:3-jdk-8
-MAINTAINER WWU eLectures team <dev.learnweb@uni-muenster.de>
+FROM java:8-jdk-alpine
+MAINTAINER WWU eLectures team <electures.dev@uni-muenster.de>
 
 ENV OPENCAST_VERSION="2.1.1" \
     OPENCAST_DISTRIBUTION="allinone" \
@@ -24,46 +24,133 @@ ENV OPENCAST_VERSION="2.1.1" \
     OPENCAST_USER="opencast" \
     OPENCAST_GROUP="opencast" \
     OPENCAST_UID="800" \
-    OPENCAST_GID="800"
+    OPENCAST_GID="800" \
+    \
+    TESSERACT_BASE_URL="https://github.com/tesseract-ocr/tessdata/raw/master" \
+    HUNSPELL_BASE_URL="http://download.services.openoffice.org/contrib/dictionaries" \
+    TESSERACT_LANG="\
+cb7eb42a7e972cec7ef904fe81825d7b547c46df684c814fdb11a930b13bca3a deu.traineddata\n\
+64adf2cc0b2a6705368aa357224d1a6739035d5fe892cd0cc457016df5b4280f eng.cube.bigrams\n\
+2b229895623934b493fe69c51fcc387295d91af8b4e43cc51748b3d269a95eed eng.cube.fold\n\
+a6f769245b0a55f42a3ce157cd19d96828483c3384c6483433ed83579ea16e36 eng.cube.lm\n\
+8f345f1c19772dd71a5214bc94175ccf647c003ab77e4143fde48f11bf3cb0ef eng.cube.nn\n\
+c2aa2854951bd823d89cc86d53a6d9712a6a885de6fbaf650ff3df48bfed85d7 eng.cube.params\n\
+e5f95de7e2754eb2df03451885277ca4573b3770816043ae2e2f09d1f7232604 eng.cube.size\n\
+8d612bef20ae3052fce0b8650575a80d87c94d772ec6d1f0c6a1ad591586ea44 eng.cube.word-freq\n\
+196bedc8a5bc8c30361c2c9518f648b45b498759cb6041827ff6fbfb8da2a8d1 eng.tesseract_cube.nn\n\
+c0515c9f1e0c79e1069fcc05c2b2f6a6841fb5e1082d695db160333c1154f06d eng.traineddata\
+    " \
+    HUNSPELL_LANG="\
+2478723ab67dd801ec6add11b1af9d32665e7859a1cb00c95bfc2b618584a802 de_AT.zip\n\
+c30bb085ba0a3d22a23aef51f4dd94ae9ae0cc811c0590ebf3713a93b209d823 de_CH.zip\n\
+220e01c3137000305247336d8d10cd550bda3990fb10e50b31633947969a34b8 de_DE_comb.zip\n\
+22e217a631977d7b377f8dd22d2bbacd2d36b32765ce13f3474b03a4a97dd700 en_AU.zip\n\
+31fac12a1b520cde686f328d3fa7560f6eba772cddc872197ff842c57a0dc1ea en_CA.zip\n\
+5869d8bd80eb2eb328ebe36b356348de4ae2acb1db6df39d1717d33f89f63728 en_GB.zip\n\
+6cc717b4de43240595662a2deef5447b06062e82380f5647196f07c9089284fa en_NZ.zip\n\
+9227f658f182c9cece797352f041a888134765c11bffc91951c010a73187baea en_US.zip\n\
+090285b721dcaabff51b467123f82a181a6904d187c90bda812c6e5f365ff19a en_ZA.zip\
+    "
 ENV OPENCAST_SCRIPTS="${OPENCAST_HOME}/docker/scripts" \
     OPENCAST_CONFIG="${OPENCAST_HOME}/etc" \
-    OPENCAST_URL="https://bitbucket.org/opencast-community/matterhorn/get/${OPENCAST_VERSION}.tar.bz2"
+    OPENCAST_URL="https://bitbucket.org/opencast-community/matterhorn/get/${OPENCAST_VERSION}.tar.gz"
 
-# Dependencies
-#   - cURL and bzip2
-#   - FFmpeg
-#   - MediaInfo
-#   - Sound eXchange (SoX)
-#   - Tesseract Open Source OCR Engine
-#   -   - english
-#   -   - german
-#   - TODO: which languages to include?
-#   - Hunspell
-#   -   - english
-#   -   - german
-#   - TODO: which languages to include?
-RUN apt-get update \
- && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      curl bzip2 \
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
+ && apk add --no-cache --virtual .build-deps \
+      tar gzip \
+      git \
+      make gcc g++ binutils-gold \
+      maven \
+      python \
+      nodejs \
+      \
+      # TODO: for tesseract; remove once package is updated
+      automake autoconf libtool \
+  \
+  # Install dependencies
+  #   - FFmpeg
+  #   - Sound eXchange (SoX)
+  #   - Tesseract Open Source OCR Engine
+  #   - Hunspell
+ && apk add --no-cache --virtual .run-deps \
       ffmpeg \
-      mediainfo \
-      sox libsox-fmt-all \
-      tesseract-ocr tesseract-ocr-eng tesseract-ocr-deu \
-      hunspell hunspell-en-us hunspell-de-de \
- && rm -rf /var/lib/apt/lists/*
-
-# Opencast
-RUN mkdir -p "${OPENCAST_SRC}" "${OPENCAST_HOME}" "${OPENCAST_DATA}" "${OPENCAST_SCRIPTS}" \
- && groupadd -r "${OPENCAST_GROUP}" -g "${OPENCAST_GID}" \
- && useradd -r -g "${OPENCAST_GROUP}" -d "${OPENCAST_HOME}" -u "${OPENCAST_UID}" "${OPENCAST_USER}" \
- && chown "${OPENCAST_USER}":"${OPENCAST_GROUP}" "${OPENCAST_SRC}" "${OPENCAST_HOME}" "${OPENCAST_DATA}"
-
-RUN cd "${OPENCAST_SRC}" \
- && curl -sSL "${OPENCAST_URL}" | tar -xj --strip 1 -C . \
- && mvn --quiet --batch-mode clean install -DskipTests=true -Dcheckstyle.skip=true \
- && tar -xzf "build/opencast-dist-${OPENCAST_DISTRIBUTION}-${OPENCAST_VERSION}.tar.gz" --strip 1 -C "${OPENCAST_HOME}" \
- && chown -R "${OPENCAST_USER}":"${OPENCAST_GROUP}" "${OPENCAST_HOME}" \
- && rm -rf "${OPENCAST_SRC}" /tmp/* ~/.npm ~/.node-gyp
+      sox \
+      hunspell \
+      \
+      # TODO: for tesseract; remove once package is updated
+      libjpeg-turbo-dev tiff-dev libpng-dev zlib-dev giflib-dev libwebp-dev \
+  \
+  # TODO: compile tesseract; remove once package is updated
+ && LEPTONICA_VERSION=1.73 \
+ && TESSERACT_VERSION=3.04.01 \
+ && mkdir -p /tmp/compile/leptonica /tmp/compile/tesseract \
+ && cd /tmp/compile \
+ && wget -q -O - "http://www.leptonica.com/source/leptonica-${LEPTONICA_VERSION}.tar.gz" | tar -xz --strip 1 -C leptonica \
+ && wget -q -O - "https://github.com/tesseract-ocr/tesseract/archive/${TESSERACT_VERSION}.tar.gz" | tar -xz --strip 1 -C tesseract \
+ && cd leptonica \
+ && ./configure \
+     --prefix=/usr \
+     --sysconfdir=/etc \
+     --mandir=/usr/share/man \
+     --infodir=/usr/share/info \
+     --localstatedir=/var \
+ && make \
+ && make install \
+ && cd ../tesseract/ \
+ && ./autogen.sh \
+ && ./configure \
+   --prefix=/usr \
+   --sysconfdir=/etc \
+   --mandir=/usr/share/man \
+   --infodir=/usr/share/info \
+   --localstatedir=/var \
+   --disable-static \
+   --disable-graphics \
+ && make \
+ && make install \
+  \
+  # Install languag files for tesseract and hunspell
+ && mkdir -p /tmp/tesseract /tmp/hunspell /usr/share/hunspell /usr/share/tesseract \
+ && echo -e ${TESSERACT_LANG} > /tmp/tesseract-sha256sum.txt \
+ && echo -e ${HUNSPELL_LANG} > /tmp/hunspell-sha256sum.txt \
+  \
+  # TODO: How to output with two spaces?
+ && sed -i "s/ /  /g" /tmp/tesseract-sha256sum.txt /tmp/hunspell-sha256sum.txt \
+ && cd /tmp/tesseract \
+ && for file in $(awk '{print $2}' /tmp/tesseract-sha256sum.txt); do \
+      wget -O "${file}" "${TESSERACT_BASE_URL}/${file}"; \
+      grep "${file}" /tmp/tesseract-sha256sum.txt | sha256sum -c -; \
+      cp "${file}" /usr/share/tesseract; \
+    done \
+ && cd /tmp/hunspell \
+ && for file in $(awk '{print $2}' /tmp/hunspell-sha256sum.txt); do \
+      wget -O "${file}" "${HUNSPELL_BASE_URL}/${file}"; \
+      grep "${file}" /tmp/hunspell-sha256sum.txt | sha256sum -c -; \
+      unzip "/tmp/hunspell/${file}"; \
+    done \
+ && cp *.aff *.dic /usr/share/hunspell \
+  \
+  # Compile frontend assets manually as the bundeled node does not run on Alpine
+ && mkdir -p "${OPENCAST_SRC}" "${OPENCAST_HOME}" "${OPENCAST_DATA}" "${OPENCAST_SCRIPTS}" \
+ && wget -O - "${OPENCAST_URL}" | tar -xz --strip 1 -C "${OPENCAST_SRC}" \
+ && cd "${OPENCAST_SRC}/modules/matterhorn-admin-ui-ng" \
+ && sed -i 's/"grunt-sass":.*/"grunt-sass": "^1.2.0",/g' package.json \
+ && npm install -g npm@2 \
+ && npm install -g grunt \
+ && npm install \
+ && grunt build --no-color --skipTests=true \
+  \
+  # Compile and install Opencast
+ && cd "${OPENCAST_SRC}" \
+ && mvn --quiet --batch-mode install -P '!frontend' -DskipTests=true -Dcheckstyle.skip=true \
+ && tar -xzf build/opencast-dist-${OPENCAST_DISTRIBUTION}-*.tar.gz --strip 1 -C "${OPENCAST_HOME}" \
+ && addgroup -S -g "${OPENCAST_GID}" "${OPENCAST_GROUP}" \
+ && adduser -S -D -H -G "${OPENCAST_GROUP}" -h "${OPENCAST_HOME}" -u "${OPENCAST_UID}" "${OPENCAST_USER}" \
+ && chown -R "${OPENCAST_USER}":"${OPENCAST_GROUP}" "${OPENCAST_HOME}" "${OPENCAST_DATA}" \
+  \
+  # Cleanup
+ && apk del .build-deps \
+ && rm -rf "${OPENCAST_SRC}" /tmp/* ~/.m2 ~/.npm ~/.node-gyp /usr/lib/node_modules
 
 COPY assets/scripts/* "${OPENCAST_SCRIPTS}/"
 COPY assets/etc/* "${OPENCAST_CONFIG}/"

--- a/Dockerfiles/allinone/assets/docker-entrypoint.sh
+++ b/Dockerfiles/allinone/assets/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright 2016 The WWU eLectures Team All rights reserved.
 #
@@ -16,63 +16,71 @@
 
 set -e
 
-source "${OPENCAST_SCRIPTS}/helper.sh"
-source "${OPENCAST_SCRIPTS}/opencast.sh"
-source "${OPENCAST_SCRIPTS}/activemq.sh"
-source "${OPENCAST_SCRIPTS}/db.sh"
-source "${OPENCAST_SCRIPTS}/hsql.sh"
-source "${OPENCAST_SCRIPTS}/jdbc.sh"
-source "${OPENCAST_SCRIPTS}/mysql.sh"
+# shellcheck source=./scripts/helper.sh
+. "${OPENCAST_SCRIPTS}/helper.sh"
+# shellcheck source=./scripts/opencast.sh
+. "${OPENCAST_SCRIPTS}/opencast.sh"
+# shellcheck source=./scripts/activemq.sh
+. "${OPENCAST_SCRIPTS}/activemq.sh"
+# shellcheck source=./scripts/db.sh
+. "${OPENCAST_SCRIPTS}/db.sh"
+# shellcheck source=./scripts/hsql.sh
+. "${OPENCAST_SCRIPTS}/hsql.sh"
+# shellcheck source=./scripts/jdbc.sh
+. "${OPENCAST_SCRIPTS}/jdbc.sh"
+# shellcheck source=./scripts/mysql.sh
+. "${OPENCAST_SCRIPTS}/mysql.sh"
 
-Opencast::Main::Check() {
-  echo "Run Opencast::Main::Check"
 
-  Opencast::Opencast::Check
-  Opencast::ActiveMQ::Check
-  Opencast::DB::Check
+opencast_main_check() {
+  echo "Run opencast_main_check"
+
+  opencast_opencast_check
+  opencast_activemq_check
+  opencast_db_check
 }
 
-Opencast::Main::Configure() {
-  echo "Run Opencast::Main::Configure"
+opencast_main_configure() {
+  echo "Run opencast_main_configure"
 
-  Opencast::Opencast::Configure
-  Opencast::ActiveMQ::Configure
-  Opencast::DB::Configure
+  opencast_opencast_configure
+  opencast_activemq_configure
+  opencast_db_configure
 }
 
-Opencast::Main::Init() {
-  echo "Run Opencast::Main::Init"
+opencast_main_init() {
+  echo "Run opencast_main_init"
 
-  if Opencast::Helper::CustomConfig; then
+  if opencast_helper_customconfig; then
     echo "Found custom config in ${OPENCAST_CUSTOM_CONFIG}"
-    echo "Run Opencast::Helper::CopyCustomConfig"
-    Opencast::Helper::CopyCustomConfig
+    echo "Run opencast_helper_copycustomconfig"
+    opencast_helper_copycustomconfig
   else
     echo "No custom config found"
-    Opencast::Main::Check
-    Opencast::Main::Configure
+    opencast_main_check
+    opencast_main_configure
   fi
 }
 
-Opencast::Main::Start() {
-  echo "Run Opencast::Main::Start"
+opencast_main_start() {
+  echo "Run opencast_main_start"
   exec "bin/start-opencast" "server"
 }
 
 case ${1} in
   app:init)
-    Opencast::Main::Init
+    opencast_main_init
     ;;
   app:start)
-    Opencast::Main::Init
-    Opencast::DB::TryToConnect
-    Opencast::Main::Start
+    opencast_main_init
+    opencast_db_trytoconnect
+    opencast_main_start
     ;;
   app:print:activemq.xml)
-    Opencast::ActiveMQ::PrintActivemq.xml
+    opencast_activemq_printactivemqxml
     ;;
   app:print:dll)
-    Opencast::DB::PrintDDL
+    opencast_db_print_ddl
     ;;
   app:help)
     echo "Usage:"

--- a/Dockerfiles/allinone/assets/scripts/activemq.sh
+++ b/Dockerfiles/allinone/assets/scripts/activemq.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright 2016 The WWU eLectures Team All rights reserved.
 #
@@ -16,25 +16,25 @@
 
 set -e
 
-Opencast::ActiveMQ::Check() {
-  echo "Run Opencast::ActiveMQ::Check"
+opencast_activemq_check() {
+  echo "Run opencast_activemq_check"
 
-  Opencast::Helper::CheckForVariables \
+  opencast_helper_checkforvariables \
     "ACTIVEMQ_BROKER_URL" \
     "ACTIVEMQ_BROKER_USERNAME" \
     "ACTIVEMQ_BROKER_PASSWORD"
 }
 
-Opencast::ActiveMQ::Configure() {
-  echo "Run Opencast::ActiveMQ::Configure"
+opencast_activemq_configure() {
+  echo "Run opencast_activemq_configure"
 
-  Opencast::Helper::ReplaceInfile "etc/custom.properties" \
+  opencast_helper_replaceinfile "etc/custom.properties" \
     "ACTIVEMQ_BROKER_URL" \
     "ACTIVEMQ_BROKER_USERNAME" \
     "ACTIVEMQ_BROKER_PASSWORD"
 }
 
-Opencast::ActiveMQ::PrintActivemq.xml() {
+opencast_activemq_printactivemqxml() {
   # TODO: read env variables and add config for jaasAuthenticationPlugin
   cat /opencast/docs/scripts/activemq/activemq.xml
 }

--- a/Dockerfiles/allinone/assets/scripts/db.sh
+++ b/Dockerfiles/allinone/assets/scripts/db.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright 2016 The WWU eLectures Team All rights reserved.
 #
@@ -19,16 +19,16 @@ set -e
 ORG_OPENCASTPROJECT_DB_VENDOR="${ORG_OPENCASTPROJECT_DB_VENDOR:-HSQL}"
 NUMER_OF_TIMES_TRYING_TO_CONNECT_TO_DB="${NUMER_OF_TIMES_TRYING_TO_CONNECT_TO_DB:-25}"
 
-Opencast::DB::Check() {
-  echo "Run Opencast::DB::Check"
+opencast_db_check() {
+  echo "Run opencast_db_check"
 
   case "$ORG_OPENCASTPROJECT_DB_VENDOR" in
     HSQL)
-      Opencast::HSQL::Check
+      opencast_hsql_check
       ;;
     MySQL)
-      Opencast::MySQL::Check
-      Opencast::JDBC::Check
+      opencast_mysql_check
+      opencast_jdbc_check
       ;;
     *)
       echo >&2 "error: ${ORG_OPENCASTPROJECT_DB_VENDOR} is currently not supported as database vendor"
@@ -37,16 +37,16 @@ Opencast::DB::Check() {
   esac
 }
 
-Opencast::DB::Configure() {
-  echo "Run Opencast::DB::Configure"
+opencast_db_configure() {
+  echo "Run opencast_db_configure"
 
   case "$ORG_OPENCASTPROJECT_DB_VENDOR" in
     HSQL)
-      Opencast::HSQL::Configure
+      opencast_hsql_configure
       ;;
     MySQL)
-      Opencast::MySQL::Configure
-      Opencast::JDBC::Configure
+      opencast_mysql_configure
+      opencast_jdbc_configure
       ;;
     *)
       echo >&2 "error: ${ORG_OPENCASTPROJECT_DB_VENDOR} is currently not supported as database vendor"
@@ -55,15 +55,15 @@ Opencast::DB::Configure() {
   esac
 }
 
-Opencast::DB::TryToConnect() {
-  echo "Run Opencast::DB::TryToConnect"
+opencast_db_trytoconnect() {
+  echo "Run opencast_db_trytoconnect"
 
   case "$ORG_OPENCASTPROJECT_DB_VENDOR" in
     HSQL)
-      Opencast::HSQL::TryToConnect
+      opencast_hsql_trytoconnect
       ;;
     MySQL)
-      Opencast::JDBC::TryToConnect
+      opencast_jdbc_trytoconnect
       ;;
     *)
       echo >&2 "error: ${ORG_OPENCASTPROJECT_DB_VENDOR} is currently not supported as database vendor"
@@ -72,15 +72,15 @@ Opencast::DB::TryToConnect() {
   esac
 }
 
-Opencast::DB::PrintDDL() {
+opencast_db_printddl() {
   echo "-- Created with Opencast version ${OPENCAST_VERSION}"
   echo
   case "$ORG_OPENCASTPROJECT_DB_VENDOR" in
     HSQL)
-      Opencast::HSQL::PrintDDL
+      opencast_hsql_printddl
       ;;
     MySQL)
-      Opencast::MySQL::PrintDDL
+      opencast_mysql_printddl
       ;;
     *)
       echo >&2 "error: ${ORG_OPENCASTPROJECT_DB_VENDOR} is currently not supported as database vendor"

--- a/Dockerfiles/allinone/assets/scripts/helper.sh
+++ b/Dockerfiles/allinone/assets/scripts/helper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright 2016 The WWU eLectures Team All rights reserved.
 #
@@ -16,34 +16,36 @@
 
 set -e
 
-Opencast::Helper::Dist::admin() {
+opencast_helper_dist_admin() {
   test "${OPENCAST_DISTRIBUTION}" = "admin"
 }
 
-Opencast::Helper::Dist::allinone() {
+opencast_helper_dist_allinone() {
   test "${OPENCAST_DISTRIBUTION}" = "allinone"
 }
 
-Opencast::Helper::Dist::presentation() {
+opencast_helper_dist_presentation() {
   test "${OPENCAST_DISTRIBUTION}" = "presentation"
 }
 
-Opencast::Helper::Dist::worker() {
+opencast_helper_dist_worker() {
   test "${OPENCAST_DISTRIBUTION}" = "worker"
 }
 
-Opencast::Helper::CustomConfig() {
+opencast_helper_customconfig() {
   test -d "${OPENCAST_CUSTOM_CONFIG}"
 }
 
-Opencast::Helper::CopyCustomConfig() {
+opencast_helper_copycustomconfig() {
   rm -rf "${OPENCAST_CONFIG}"
   cp -r "${OPENCAST_CUSTOM_CONFIG}" "${OPENCAST_CONFIG}"
 }
 
-Opencast::Helper::CheckForVariables() {
+opencast_helper_checkforvariables() {
   for var in "$@"; do
-    if test -z "${!var}"; then
+    eval exp_var="\$${var}"
+    # shellcheck disable=SC2154
+    if test -z "${exp_var}"; then
       echo >&2 "error: missing Opencast ${var} environment variables"
       echo >&2 "  Did you forget to -e ${var}=value ?"
       exit 1
@@ -52,17 +54,18 @@ Opencast::Helper::CheckForVariables() {
 }
 
 # Replaces {{$2...}} with $!2... in file $1
-Opencast::Helper::ReplaceInfile() {
-  local file="$1"
+opencast_helper_replaceinfile() {
+  file="$1"
   shift
   for var in "$@"; do
-    sed -ri "s/[{]{2}${var}[}]{2}/$( echo ${!var} | sed -e 's/[\/&]/\\&/g' )/g" "${file}"
+    eval exp_var="\$${var}"
+    sed -ri "s/[{]{2}${var}[}]{2}/$( echo ${exp_var} | sed -e 's/[\/&]/\\&/g' )/g" "${file}"
   done
 }
 
 # Deletes lines containing {{$2...}} in file $1
-Opencast::Helper::DeleteInfile() {
-  local file="$1"
+opencast_helper_deleteinfile() {
+  file="$1"
   shift
   for var in "$@"; do
     sed -ri "/[{]{2}${var}[}]{2}/d" "${file}"

--- a/Dockerfiles/allinone/assets/scripts/hsql.sh
+++ b/Dockerfiles/allinone/assets/scripts/hsql.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright 2016 The WWU eLectures Team All rights reserved.
 #
@@ -16,30 +16,30 @@
 
 set -e
 
-Opencast::HSQL::Check() {
-  echo "Run Opencast::HSQL::Check"
+opencast_hsql_check() {
+  echo "Run opencast_hsql_check"
 
-  ORG_OPENCASTPROJECT_DB_DDL_GENERATION="true"
+  export ORG_OPENCASTPROJECT_DB_DDL_GENERATION="true"
 }
 
-Opencast::HSQL::Configure() {
-  echo "Run Opencast::HSQL::Configure"
+opencast_hsql_configure() {
+  echo "Run opencast_hsql_configure"
 
-  Opencast::Helper::DeleteInfile "etc/custom.properties" \
+  opencast_helper_deleteinfile "etc/custom.properties" \
     "ORG_OPENCASTPROJECT_DB_VENDOR" \
     "ORG_OPENCASTPROJECT_DB_JDBC_DRIVER" \
     "ORG_OPENCASTPROJECT_DB_JDBC_URL" \
     "ORG_OPENCASTPROJECT_DB_JDBC_USER" \
     "ORG_OPENCASTPROJECT_DB_JDBC_PASS"
 
-  Opencast::Helper::ReplaceInfile "etc/custom.properties" \
+  opencast_helper_replaceinfile "etc/custom.properties" \
     "ORG_OPENCASTPROJECT_DB_DDL_GENERATION"
 }
 
-Opencast::HSQL::TryToConnect() {
-  echo "Run Opencast::HSQL::TryToConnect"
+opencast_hsql_trytoconnect() {
+  echo "Run opencast_hsql_trytoconnect"
 }
 
-Opencast::HSQL::PrintDDL() {
+opencast_hsql_printddl() {
   echo "-- Database for HSQL is created automatically"
 }

--- a/Dockerfiles/allinone/assets/scripts/jdbc.sh
+++ b/Dockerfiles/allinone/assets/scripts/jdbc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright 2016 The WWU eLectures Team All rights reserved.
 #
@@ -16,12 +16,12 @@
 
 set -e
 
-Opencast::JDBC::Check() {
-  echo "Run Opencast::JDBC::Check"
+opencast_jdbc_check() {
+  echo "Run opencast_jdbc_check"
 
   ORG_OPENCASTPROJECT_DB_DDL_GENERATION="${ORG_OPENCASTPROJECT_DB_DDL_GENERATION:-false}"
 
-  Opencast::Helper::CheckForVariables \
+  opencast_helper_checkforvariables \
     "ORG_OPENCASTPROJECT_DB_DDL_GENERATION" \
     "ORG_OPENCASTPROJECT_DB_JDBC_DRIVER" \
     "ORG_OPENCASTPROJECT_DB_JDBC_URL" \
@@ -29,10 +29,10 @@ Opencast::JDBC::Check() {
     "ORG_OPENCASTPROJECT_DB_JDBC_PASS"
 }
 
-Opencast::JDBC::Configure() {
-  echo "Run Opencast::JDBC::Configure"
+opencast_jdbc_configure() {
+  echo "Run opencast_jdbc_configure"
 
-  Opencast::Helper::ReplaceInfile "etc/custom.properties" \
+  opencast_helper_replaceinfile "etc/custom.properties" \
     "ORG_OPENCASTPROJECT_DB_VENDOR" \
     "ORG_OPENCASTPROJECT_DB_DDL_GENERATION" \
     "ORG_OPENCASTPROJECT_DB_JDBC_DRIVER" \
@@ -41,8 +41,8 @@ Opencast::JDBC::Configure() {
     "ORG_OPENCASTPROJECT_DB_JDBC_PASS"
 }
 
-Opencast::JDBC::TryToConnect() {
-  echo "Run Opencast::JDBC::TryToConnect"
+opencast_jdbc_trytoconnect() {
+  echo "Run opencast_jdbc_trytoconnect"
 
   driver=$(awk -F "=" '/org\.opencastproject\.db\.jdbc\.driver/ {print $2}' etc/custom.properties | tr -d ' ')
   url=$(awk -F "=" '/org\.opencastproject\.db\.jdbc\.url/ {print $2}' etc/custom.properties | tr -d ' ')

--- a/Dockerfiles/allinone/assets/scripts/mysql.sh
+++ b/Dockerfiles/allinone/assets/scripts/mysql.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright 2016 The WWU eLectures Team All rights reserved.
 #
@@ -16,15 +16,15 @@
 
 set -e
 
-Opencast::MySQL::Check() {
-  echo "Run Opencast::MySQL::Check"
-  ORG_OPENCASTPROJECT_DB_JDBC_DRIVER="com.mysql.jdbc.Driver"
+opencast_mysql_check() {
+  echo "Run opencast_mysql_check"
+  export ORG_OPENCASTPROJECT_DB_JDBC_DRIVER="com.mysql.jdbc.Driver"
 }
 
-Opencast::MySQL::Configure() {
-  echo "Run Opencast::MySQL::Configure"
+opencast_mysql_configure() {
+  echo "Run opencast_mysql_configure"
 }
 
-Opencast::MySQL::PrintDDL() {
+opencast_mysql_printddl() {
   cat /opencast/docs/scripts/ddl/mysql5.sql
 }

--- a/Dockerfiles/allinone/assets/scripts/opencast.sh
+++ b/Dockerfiles/allinone/assets/scripts/opencast.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright 2016 The WWU eLectures Team All rights reserved.
 #
@@ -19,15 +19,17 @@ set -e
 ORG_OPENCASTPROJECT_ADMIN_EMAIL="${ORG_OPENCASTPROJECT_ADMIN_EMAIL:-admin@localhost}"
 ORG_OPENCASTPROJECT_DOWNLOAD_URL="${ORG_OPENCASTPROJECT_DOWNLOAD_URL:-\$\{org.opencastproject.server.url\}/static}"
 
-if Opencast::Helper::Dist::allinone; then
-  ORG_OPENCASTPROJECT_FILE_REPO_URL='${org.opencastproject.server.url}'
+if opencast_helper_dist_allinone; then
+  # shellcheck disable=SC2016
+  export ORG_OPENCASTPROJECT_FILE_REPO_URL='${org.opencastproject.server.url}'
 else
-  ORG_OPENCASTPROJECT_FILE_REPO_URL='${org.opencastproject.admin.ui.url}'
+  # shellcheck disable=SC2016
+  export ORG_OPENCASTPROJECT_FILE_REPO_URL='${org.opencastproject.admin.ui.url}'
 fi
 
-Opencast::Opencast::Check() {
-  echo "Run Opencast::Opencast::Check"
-  Opencast::Helper::CheckForVariables \
+opencast_opencast_check() {
+  echo "Run opencast_opencast_check"
+  opencast_helper_checkforvariables \
     "ORG_OPENCASTPROJECT_SERVER_URL" \
     "ORG_OPENCASTPROJECT_SECURITY_ADMIN_USER" \
     "ORG_OPENCASTPROJECT_SECURITY_ADMIN_PASS" \
@@ -35,16 +37,16 @@ Opencast::Opencast::Check() {
     "ORG_OPENCASTPROJECT_SECURITY_DIGEST_PASS" \
     "ORG_OPENCASTPROJECT_FILE_REPO_URL"
 
-  if ! Opencast::Helper::Dist::allinone; then
-    Opencast::Helper::CheckForVariables \
+  if ! opencast_helper_dist_allinone; then
+    opencast_helper_checkforvariables \
       "PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL" \
       "PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL"
   fi
 }
 
-Opencast::Opencast::Configure() {
-  echo "Run Opencast::Opencast::Configure"
-  Opencast::Helper::ReplaceInfile "etc/custom.properties" \
+opencast_opencast_configure() {
+  echo "Run opencast_opencast_configure"
+  opencast_helper_replaceinfile "etc/custom.properties" \
     "ORG_OPENCASTPROJECT_ADMIN_EMAIL" \
     "ORG_OPENCASTPROJECT_SERVER_URL" \
     "ORG_OPENCASTPROJECT_SECURITY_ADMIN_USER" \
@@ -54,8 +56,8 @@ Opencast::Opencast::Configure() {
     "ORG_OPENCASTPROJECT_FILE_REPO_URL" \
     "ORG_OPENCASTPROJECT_DOWNLOAD_URL"
 
-  if ! Opencast::Helper::Dist::allinone; then
-    Opencast::Helper::ReplaceInfile "etc/org.opencastproject.organization-mh_default_org.cfg" \
+  if ! opencast_helper_dist_allinone; then
+    opencast_helper_replaceinfile "etc/org.opencastproject.organization-mh_default_org.cfg" \
       "PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL" \
       "PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL"
   fi

--- a/Dockerfiles/presentation/Dockerfile
+++ b/Dockerfiles/presentation/Dockerfile
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM maven:3-jdk-8
-MAINTAINER WWU eLectures team <dev.learnweb@uni-muenster.de>
+FROM java:8-jdk-alpine
+MAINTAINER WWU eLectures team <electures.dev@uni-muenster.de>
 
 ENV OPENCAST_VERSION="2.1.1" \
     OPENCAST_DISTRIBUTION="presentation" \
@@ -24,46 +24,133 @@ ENV OPENCAST_VERSION="2.1.1" \
     OPENCAST_USER="opencast" \
     OPENCAST_GROUP="opencast" \
     OPENCAST_UID="800" \
-    OPENCAST_GID="800"
+    OPENCAST_GID="800" \
+    \
+    TESSERACT_BASE_URL="https://github.com/tesseract-ocr/tessdata/raw/master" \
+    HUNSPELL_BASE_URL="http://download.services.openoffice.org/contrib/dictionaries" \
+    TESSERACT_LANG="\
+cb7eb42a7e972cec7ef904fe81825d7b547c46df684c814fdb11a930b13bca3a deu.traineddata\n\
+64adf2cc0b2a6705368aa357224d1a6739035d5fe892cd0cc457016df5b4280f eng.cube.bigrams\n\
+2b229895623934b493fe69c51fcc387295d91af8b4e43cc51748b3d269a95eed eng.cube.fold\n\
+a6f769245b0a55f42a3ce157cd19d96828483c3384c6483433ed83579ea16e36 eng.cube.lm\n\
+8f345f1c19772dd71a5214bc94175ccf647c003ab77e4143fde48f11bf3cb0ef eng.cube.nn\n\
+c2aa2854951bd823d89cc86d53a6d9712a6a885de6fbaf650ff3df48bfed85d7 eng.cube.params\n\
+e5f95de7e2754eb2df03451885277ca4573b3770816043ae2e2f09d1f7232604 eng.cube.size\n\
+8d612bef20ae3052fce0b8650575a80d87c94d772ec6d1f0c6a1ad591586ea44 eng.cube.word-freq\n\
+196bedc8a5bc8c30361c2c9518f648b45b498759cb6041827ff6fbfb8da2a8d1 eng.tesseract_cube.nn\n\
+c0515c9f1e0c79e1069fcc05c2b2f6a6841fb5e1082d695db160333c1154f06d eng.traineddata\
+    " \
+    HUNSPELL_LANG="\
+2478723ab67dd801ec6add11b1af9d32665e7859a1cb00c95bfc2b618584a802 de_AT.zip\n\
+c30bb085ba0a3d22a23aef51f4dd94ae9ae0cc811c0590ebf3713a93b209d823 de_CH.zip\n\
+220e01c3137000305247336d8d10cd550bda3990fb10e50b31633947969a34b8 de_DE_comb.zip\n\
+22e217a631977d7b377f8dd22d2bbacd2d36b32765ce13f3474b03a4a97dd700 en_AU.zip\n\
+31fac12a1b520cde686f328d3fa7560f6eba772cddc872197ff842c57a0dc1ea en_CA.zip\n\
+5869d8bd80eb2eb328ebe36b356348de4ae2acb1db6df39d1717d33f89f63728 en_GB.zip\n\
+6cc717b4de43240595662a2deef5447b06062e82380f5647196f07c9089284fa en_NZ.zip\n\
+9227f658f182c9cece797352f041a888134765c11bffc91951c010a73187baea en_US.zip\n\
+090285b721dcaabff51b467123f82a181a6904d187c90bda812c6e5f365ff19a en_ZA.zip\
+    "
 ENV OPENCAST_SCRIPTS="${OPENCAST_HOME}/docker/scripts" \
     OPENCAST_CONFIG="${OPENCAST_HOME}/etc" \
-    OPENCAST_URL="https://bitbucket.org/opencast-community/matterhorn/get/${OPENCAST_VERSION}.tar.bz2"
+    OPENCAST_URL="https://bitbucket.org/opencast-community/matterhorn/get/${OPENCAST_VERSION}.tar.gz"
 
-# Dependencies
-#   - cURL and bzip2
-#   - FFmpeg
-#   - MediaInfo
-#   - Sound eXchange (SoX)
-#   - Tesseract Open Source OCR Engine
-#   -   - english
-#   -   - german
-#   - TODO: which languages to include?
-#   - Hunspell
-#   -   - english
-#   -   - german
-#   - TODO: which languages to include?
-RUN apt-get update \
- && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      curl bzip2 \
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
+ && apk add --no-cache --virtual .build-deps \
+      tar gzip \
+      git \
+      make gcc g++ binutils-gold \
+      maven \
+      python \
+      nodejs \
+      \
+      # TODO: for tesseract; remove once package is updated
+      automake autoconf libtool \
+  \
+  # Install dependencies
+  #   - FFmpeg
+  #   - Sound eXchange (SoX)
+  #   - Tesseract Open Source OCR Engine
+  #   - Hunspell
+ && apk add --no-cache --virtual .run-deps \
       ffmpeg \
-      mediainfo \
-      sox libsox-fmt-all \
-      tesseract-ocr tesseract-ocr-eng tesseract-ocr-deu \
-      hunspell hunspell-en-us hunspell-de-de \
- && rm -rf /var/lib/apt/lists/*
-
-# Opencast
-RUN mkdir -p "${OPENCAST_SRC}" "${OPENCAST_HOME}" "${OPENCAST_DATA}" "${OPENCAST_SCRIPTS}" \
- && groupadd -r "${OPENCAST_GROUP}" -g "${OPENCAST_GID}" \
- && useradd -r -g "${OPENCAST_GROUP}" -d "${OPENCAST_HOME}" -u "${OPENCAST_UID}" "${OPENCAST_USER}" \
- && chown "${OPENCAST_USER}":"${OPENCAST_GROUP}" "${OPENCAST_SRC}" "${OPENCAST_HOME}" "${OPENCAST_DATA}"
-
-RUN cd "${OPENCAST_SRC}" \
- && curl -sSL "${OPENCAST_URL}" | tar -xj --strip 1 -C . \
- && mvn --quiet --batch-mode clean install -DskipTests=true -Dcheckstyle.skip=true \
- && tar -xzf "build/opencast-dist-${OPENCAST_DISTRIBUTION}-${OPENCAST_VERSION}.tar.gz" --strip 1 -C "${OPENCAST_HOME}" \
- && chown -R "${OPENCAST_USER}":"${OPENCAST_GROUP}" "${OPENCAST_HOME}" \
- && rm -rf "${OPENCAST_SRC}" /tmp/* ~/.npm ~/.node-gyp
+      sox \
+      hunspell \
+      \
+      # TODO: for tesseract; remove once package is updated
+      libjpeg-turbo-dev tiff-dev libpng-dev zlib-dev giflib-dev libwebp-dev \
+  \
+  # TODO: compile tesseract; remove once package is updated
+ && LEPTONICA_VERSION=1.73 \
+ && TESSERACT_VERSION=3.04.01 \
+ && mkdir -p /tmp/compile/leptonica /tmp/compile/tesseract \
+ && cd /tmp/compile \
+ && wget -q -O - "http://www.leptonica.com/source/leptonica-${LEPTONICA_VERSION}.tar.gz" | tar -xz --strip 1 -C leptonica \
+ && wget -q -O - "https://github.com/tesseract-ocr/tesseract/archive/${TESSERACT_VERSION}.tar.gz" | tar -xz --strip 1 -C tesseract \
+ && cd leptonica \
+ && ./configure \
+     --prefix=/usr \
+     --sysconfdir=/etc \
+     --mandir=/usr/share/man \
+     --infodir=/usr/share/info \
+     --localstatedir=/var \
+ && make \
+ && make install \
+ && cd ../tesseract/ \
+ && ./autogen.sh \
+ && ./configure \
+   --prefix=/usr \
+   --sysconfdir=/etc \
+   --mandir=/usr/share/man \
+   --infodir=/usr/share/info \
+   --localstatedir=/var \
+   --disable-static \
+   --disable-graphics \
+ && make \
+ && make install \
+  \
+  # Install languag files for tesseract and hunspell
+ && mkdir -p /tmp/tesseract /tmp/hunspell /usr/share/hunspell /usr/share/tesseract \
+ && echo -e ${TESSERACT_LANG} > /tmp/tesseract-sha256sum.txt \
+ && echo -e ${HUNSPELL_LANG} > /tmp/hunspell-sha256sum.txt \
+  \
+  # TODO: How to output with two spaces?
+ && sed -i "s/ /  /g" /tmp/tesseract-sha256sum.txt /tmp/hunspell-sha256sum.txt \
+ && cd /tmp/tesseract \
+ && for file in $(awk '{print $2}' /tmp/tesseract-sha256sum.txt); do \
+      wget -O "${file}" "${TESSERACT_BASE_URL}/${file}"; \
+      grep "${file}" /tmp/tesseract-sha256sum.txt | sha256sum -c -; \
+      cp "${file}" /usr/share/tesseract; \
+    done \
+ && cd /tmp/hunspell \
+ && for file in $(awk '{print $2}' /tmp/hunspell-sha256sum.txt); do \
+      wget -O "${file}" "${HUNSPELL_BASE_URL}/${file}"; \
+      grep "${file}" /tmp/hunspell-sha256sum.txt | sha256sum -c -; \
+      unzip "/tmp/hunspell/${file}"; \
+    done \
+ && cp *.aff *.dic /usr/share/hunspell \
+  \
+  # Compile frontend assets manually as the bundeled node does not run on Alpine
+ && mkdir -p "${OPENCAST_SRC}" "${OPENCAST_HOME}" "${OPENCAST_DATA}" "${OPENCAST_SCRIPTS}" \
+ && wget -O - "${OPENCAST_URL}" | tar -xz --strip 1 -C "${OPENCAST_SRC}" \
+ && cd "${OPENCAST_SRC}/modules/matterhorn-admin-ui-ng" \
+ && sed -i 's/"grunt-sass":.*/"grunt-sass": "^1.2.0",/g' package.json \
+ && npm install -g npm@2 \
+ && npm install -g grunt \
+ && npm install \
+ && grunt build --no-color --skipTests=true \
+  \
+  # Compile and install Opencast
+ && cd "${OPENCAST_SRC}" \
+ && mvn --quiet --batch-mode install -P '!frontend' -DskipTests=true -Dcheckstyle.skip=true \
+ && tar -xzf build/opencast-dist-${OPENCAST_DISTRIBUTION}-*.tar.gz --strip 1 -C "${OPENCAST_HOME}" \
+ && addgroup -S -g "${OPENCAST_GID}" "${OPENCAST_GROUP}" \
+ && adduser -S -D -H -G "${OPENCAST_GROUP}" -h "${OPENCAST_HOME}" -u "${OPENCAST_UID}" "${OPENCAST_USER}" \
+ && chown -R "${OPENCAST_USER}":"${OPENCAST_GROUP}" "${OPENCAST_HOME}" "${OPENCAST_DATA}" \
+  \
+  # Cleanup
+ && apk del .build-deps \
+ && rm -rf "${OPENCAST_SRC}" /tmp/* ~/.m2 ~/.npm ~/.node-gyp /usr/lib/node_modules
 
 COPY assets/scripts/* "${OPENCAST_SCRIPTS}/"
 COPY assets/etc/* "${OPENCAST_CONFIG}/"

--- a/Dockerfiles/presentation/assets/docker-entrypoint.sh
+++ b/Dockerfiles/presentation/assets/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright 2016 The WWU eLectures Team All rights reserved.
 #
@@ -16,63 +16,71 @@
 
 set -e
 
-source "${OPENCAST_SCRIPTS}/helper.sh"
-source "${OPENCAST_SCRIPTS}/opencast.sh"
-source "${OPENCAST_SCRIPTS}/activemq.sh"
-source "${OPENCAST_SCRIPTS}/db.sh"
-source "${OPENCAST_SCRIPTS}/hsql.sh"
-source "${OPENCAST_SCRIPTS}/jdbc.sh"
-source "${OPENCAST_SCRIPTS}/mysql.sh"
+# shellcheck source=./scripts/helper.sh
+. "${OPENCAST_SCRIPTS}/helper.sh"
+# shellcheck source=./scripts/opencast.sh
+. "${OPENCAST_SCRIPTS}/opencast.sh"
+# shellcheck source=./scripts/activemq.sh
+. "${OPENCAST_SCRIPTS}/activemq.sh"
+# shellcheck source=./scripts/db.sh
+. "${OPENCAST_SCRIPTS}/db.sh"
+# shellcheck source=./scripts/hsql.sh
+. "${OPENCAST_SCRIPTS}/hsql.sh"
+# shellcheck source=./scripts/jdbc.sh
+. "${OPENCAST_SCRIPTS}/jdbc.sh"
+# shellcheck source=./scripts/mysql.sh
+. "${OPENCAST_SCRIPTS}/mysql.sh"
 
-Opencast::Main::Check() {
-  echo "Run Opencast::Main::Check"
 
-  Opencast::Opencast::Check
-  Opencast::ActiveMQ::Check
-  Opencast::DB::Check
+opencast_main_check() {
+  echo "Run opencast_main_check"
+
+  opencast_opencast_check
+  opencast_activemq_check
+  opencast_db_check
 }
 
-Opencast::Main::Configure() {
-  echo "Run Opencast::Main::Configure"
+opencast_main_configure() {
+  echo "Run opencast_main_configure"
 
-  Opencast::Opencast::Configure
-  Opencast::ActiveMQ::Configure
-  Opencast::DB::Configure
+  opencast_opencast_configure
+  opencast_activemq_configure
+  opencast_db_configure
 }
 
-Opencast::Main::Init() {
-  echo "Run Opencast::Main::Init"
+opencast_main_init() {
+  echo "Run opencast_main_init"
 
-  if Opencast::Helper::CustomConfig; then
+  if opencast_helper_customconfig; then
     echo "Found custom config in ${OPENCAST_CUSTOM_CONFIG}"
-    echo "Run Opencast::Helper::CopyCustomConfig"
-    Opencast::Helper::CopyCustomConfig
+    echo "Run opencast_helper_copycustomconfig"
+    opencast_helper_copycustomconfig
   else
     echo "No custom config found"
-    Opencast::Main::Check
-    Opencast::Main::Configure
+    opencast_main_check
+    opencast_main_configure
   fi
 }
 
-Opencast::Main::Start() {
-  echo "Run Opencast::Main::Start"
+opencast_main_start() {
+  echo "Run opencast_main_start"
   exec "bin/start-opencast" "server"
 }
 
 case ${1} in
   app:init)
-    Opencast::Main::Init
+    opencast_main_init
     ;;
   app:start)
-    Opencast::Main::Init
-    Opencast::DB::TryToConnect
-    Opencast::Main::Start
+    opencast_main_init
+    opencast_db_trytoconnect
+    opencast_main_start
     ;;
   app:print:activemq.xml)
-    Opencast::ActiveMQ::PrintActivemq.xml
+    opencast_activemq_printactivemqxml
     ;;
   app:print:dll)
-    Opencast::DB::PrintDDL
+    opencast_db_print_ddl
     ;;
   app:help)
     echo "Usage:"

--- a/Dockerfiles/presentation/assets/scripts/activemq.sh
+++ b/Dockerfiles/presentation/assets/scripts/activemq.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright 2016 The WWU eLectures Team All rights reserved.
 #
@@ -16,25 +16,25 @@
 
 set -e
 
-Opencast::ActiveMQ::Check() {
-  echo "Run Opencast::ActiveMQ::Check"
+opencast_activemq_check() {
+  echo "Run opencast_activemq_check"
 
-  Opencast::Helper::CheckForVariables \
+  opencast_helper_checkforvariables \
     "ACTIVEMQ_BROKER_URL" \
     "ACTIVEMQ_BROKER_USERNAME" \
     "ACTIVEMQ_BROKER_PASSWORD"
 }
 
-Opencast::ActiveMQ::Configure() {
-  echo "Run Opencast::ActiveMQ::Configure"
+opencast_activemq_configure() {
+  echo "Run opencast_activemq_configure"
 
-  Opencast::Helper::ReplaceInfile "etc/custom.properties" \
+  opencast_helper_replaceinfile "etc/custom.properties" \
     "ACTIVEMQ_BROKER_URL" \
     "ACTIVEMQ_BROKER_USERNAME" \
     "ACTIVEMQ_BROKER_PASSWORD"
 }
 
-Opencast::ActiveMQ::PrintActivemq.xml() {
+opencast_activemq_printactivemqxml() {
   # TODO: read env variables and add config for jaasAuthenticationPlugin
   cat /opencast/docs/scripts/activemq/activemq.xml
 }

--- a/Dockerfiles/presentation/assets/scripts/db.sh
+++ b/Dockerfiles/presentation/assets/scripts/db.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright 2016 The WWU eLectures Team All rights reserved.
 #
@@ -19,16 +19,16 @@ set -e
 ORG_OPENCASTPROJECT_DB_VENDOR="${ORG_OPENCASTPROJECT_DB_VENDOR:-HSQL}"
 NUMER_OF_TIMES_TRYING_TO_CONNECT_TO_DB="${NUMER_OF_TIMES_TRYING_TO_CONNECT_TO_DB:-25}"
 
-Opencast::DB::Check() {
-  echo "Run Opencast::DB::Check"
+opencast_db_check() {
+  echo "Run opencast_db_check"
 
   case "$ORG_OPENCASTPROJECT_DB_VENDOR" in
     HSQL)
-      Opencast::HSQL::Check
+      opencast_hsql_check
       ;;
     MySQL)
-      Opencast::MySQL::Check
-      Opencast::JDBC::Check
+      opencast_mysql_check
+      opencast_jdbc_check
       ;;
     *)
       echo >&2 "error: ${ORG_OPENCASTPROJECT_DB_VENDOR} is currently not supported as database vendor"
@@ -37,16 +37,16 @@ Opencast::DB::Check() {
   esac
 }
 
-Opencast::DB::Configure() {
-  echo "Run Opencast::DB::Configure"
+opencast_db_configure() {
+  echo "Run opencast_db_configure"
 
   case "$ORG_OPENCASTPROJECT_DB_VENDOR" in
     HSQL)
-      Opencast::HSQL::Configure
+      opencast_hsql_configure
       ;;
     MySQL)
-      Opencast::MySQL::Configure
-      Opencast::JDBC::Configure
+      opencast_mysql_configure
+      opencast_jdbc_configure
       ;;
     *)
       echo >&2 "error: ${ORG_OPENCASTPROJECT_DB_VENDOR} is currently not supported as database vendor"
@@ -55,15 +55,15 @@ Opencast::DB::Configure() {
   esac
 }
 
-Opencast::DB::TryToConnect() {
-  echo "Run Opencast::DB::TryToConnect"
+opencast_db_trytoconnect() {
+  echo "Run opencast_db_trytoconnect"
 
   case "$ORG_OPENCASTPROJECT_DB_VENDOR" in
     HSQL)
-      Opencast::HSQL::TryToConnect
+      opencast_hsql_trytoconnect
       ;;
     MySQL)
-      Opencast::JDBC::TryToConnect
+      opencast_jdbc_trytoconnect
       ;;
     *)
       echo >&2 "error: ${ORG_OPENCASTPROJECT_DB_VENDOR} is currently not supported as database vendor"
@@ -72,15 +72,15 @@ Opencast::DB::TryToConnect() {
   esac
 }
 
-Opencast::DB::PrintDDL() {
+opencast_db_printddl() {
   echo "-- Created with Opencast version ${OPENCAST_VERSION}"
   echo
   case "$ORG_OPENCASTPROJECT_DB_VENDOR" in
     HSQL)
-      Opencast::HSQL::PrintDDL
+      opencast_hsql_printddl
       ;;
     MySQL)
-      Opencast::MySQL::PrintDDL
+      opencast_mysql_printddl
       ;;
     *)
       echo >&2 "error: ${ORG_OPENCASTPROJECT_DB_VENDOR} is currently not supported as database vendor"

--- a/Dockerfiles/presentation/assets/scripts/helper.sh
+++ b/Dockerfiles/presentation/assets/scripts/helper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright 2016 The WWU eLectures Team All rights reserved.
 #
@@ -16,34 +16,36 @@
 
 set -e
 
-Opencast::Helper::Dist::admin() {
+opencast_helper_dist_admin() {
   test "${OPENCAST_DISTRIBUTION}" = "admin"
 }
 
-Opencast::Helper::Dist::allinone() {
+opencast_helper_dist_allinone() {
   test "${OPENCAST_DISTRIBUTION}" = "allinone"
 }
 
-Opencast::Helper::Dist::presentation() {
+opencast_helper_dist_presentation() {
   test "${OPENCAST_DISTRIBUTION}" = "presentation"
 }
 
-Opencast::Helper::Dist::worker() {
+opencast_helper_dist_worker() {
   test "${OPENCAST_DISTRIBUTION}" = "worker"
 }
 
-Opencast::Helper::CustomConfig() {
+opencast_helper_customconfig() {
   test -d "${OPENCAST_CUSTOM_CONFIG}"
 }
 
-Opencast::Helper::CopyCustomConfig() {
+opencast_helper_copycustomconfig() {
   rm -rf "${OPENCAST_CONFIG}"
   cp -r "${OPENCAST_CUSTOM_CONFIG}" "${OPENCAST_CONFIG}"
 }
 
-Opencast::Helper::CheckForVariables() {
+opencast_helper_checkforvariables() {
   for var in "$@"; do
-    if test -z "${!var}"; then
+    eval exp_var="\$${var}"
+    # shellcheck disable=SC2154
+    if test -z "${exp_var}"; then
       echo >&2 "error: missing Opencast ${var} environment variables"
       echo >&2 "  Did you forget to -e ${var}=value ?"
       exit 1
@@ -52,17 +54,18 @@ Opencast::Helper::CheckForVariables() {
 }
 
 # Replaces {{$2...}} with $!2... in file $1
-Opencast::Helper::ReplaceInfile() {
-  local file="$1"
+opencast_helper_replaceinfile() {
+  file="$1"
   shift
   for var in "$@"; do
-    sed -ri "s/[{]{2}${var}[}]{2}/$( echo ${!var} | sed -e 's/[\/&]/\\&/g' )/g" "${file}"
+    eval exp_var="\$${var}"
+    sed -ri "s/[{]{2}${var}[}]{2}/$( echo ${exp_var} | sed -e 's/[\/&]/\\&/g' )/g" "${file}"
   done
 }
 
 # Deletes lines containing {{$2...}} in file $1
-Opencast::Helper::DeleteInfile() {
-  local file="$1"
+opencast_helper_deleteinfile() {
+  file="$1"
   shift
   for var in "$@"; do
     sed -ri "/[{]{2}${var}[}]{2}/d" "${file}"

--- a/Dockerfiles/presentation/assets/scripts/hsql.sh
+++ b/Dockerfiles/presentation/assets/scripts/hsql.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright 2016 The WWU eLectures Team All rights reserved.
 #
@@ -16,30 +16,30 @@
 
 set -e
 
-Opencast::HSQL::Check() {
-  echo "Run Opencast::HSQL::Check"
+opencast_hsql_check() {
+  echo "Run opencast_hsql_check"
 
-  ORG_OPENCASTPROJECT_DB_DDL_GENERATION="true"
+  export ORG_OPENCASTPROJECT_DB_DDL_GENERATION="true"
 }
 
-Opencast::HSQL::Configure() {
-  echo "Run Opencast::HSQL::Configure"
+opencast_hsql_configure() {
+  echo "Run opencast_hsql_configure"
 
-  Opencast::Helper::DeleteInfile "etc/custom.properties" \
+  opencast_helper_deleteinfile "etc/custom.properties" \
     "ORG_OPENCASTPROJECT_DB_VENDOR" \
     "ORG_OPENCASTPROJECT_DB_JDBC_DRIVER" \
     "ORG_OPENCASTPROJECT_DB_JDBC_URL" \
     "ORG_OPENCASTPROJECT_DB_JDBC_USER" \
     "ORG_OPENCASTPROJECT_DB_JDBC_PASS"
 
-  Opencast::Helper::ReplaceInfile "etc/custom.properties" \
+  opencast_helper_replaceinfile "etc/custom.properties" \
     "ORG_OPENCASTPROJECT_DB_DDL_GENERATION"
 }
 
-Opencast::HSQL::TryToConnect() {
-  echo "Run Opencast::HSQL::TryToConnect"
+opencast_hsql_trytoconnect() {
+  echo "Run opencast_hsql_trytoconnect"
 }
 
-Opencast::HSQL::PrintDDL() {
+opencast_hsql_printddl() {
   echo "-- Database for HSQL is created automatically"
 }

--- a/Dockerfiles/presentation/assets/scripts/jdbc.sh
+++ b/Dockerfiles/presentation/assets/scripts/jdbc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright 2016 The WWU eLectures Team All rights reserved.
 #
@@ -16,12 +16,12 @@
 
 set -e
 
-Opencast::JDBC::Check() {
-  echo "Run Opencast::JDBC::Check"
+opencast_jdbc_check() {
+  echo "Run opencast_jdbc_check"
 
   ORG_OPENCASTPROJECT_DB_DDL_GENERATION="${ORG_OPENCASTPROJECT_DB_DDL_GENERATION:-false}"
 
-  Opencast::Helper::CheckForVariables \
+  opencast_helper_checkforvariables \
     "ORG_OPENCASTPROJECT_DB_DDL_GENERATION" \
     "ORG_OPENCASTPROJECT_DB_JDBC_DRIVER" \
     "ORG_OPENCASTPROJECT_DB_JDBC_URL" \
@@ -29,10 +29,10 @@ Opencast::JDBC::Check() {
     "ORG_OPENCASTPROJECT_DB_JDBC_PASS"
 }
 
-Opencast::JDBC::Configure() {
-  echo "Run Opencast::JDBC::Configure"
+opencast_jdbc_configure() {
+  echo "Run opencast_jdbc_configure"
 
-  Opencast::Helper::ReplaceInfile "etc/custom.properties" \
+  opencast_helper_replaceinfile "etc/custom.properties" \
     "ORG_OPENCASTPROJECT_DB_VENDOR" \
     "ORG_OPENCASTPROJECT_DB_DDL_GENERATION" \
     "ORG_OPENCASTPROJECT_DB_JDBC_DRIVER" \
@@ -41,8 +41,8 @@ Opencast::JDBC::Configure() {
     "ORG_OPENCASTPROJECT_DB_JDBC_PASS"
 }
 
-Opencast::JDBC::TryToConnect() {
-  echo "Run Opencast::JDBC::TryToConnect"
+opencast_jdbc_trytoconnect() {
+  echo "Run opencast_jdbc_trytoconnect"
 
   driver=$(awk -F "=" '/org\.opencastproject\.db\.jdbc\.driver/ {print $2}' etc/custom.properties | tr -d ' ')
   url=$(awk -F "=" '/org\.opencastproject\.db\.jdbc\.url/ {print $2}' etc/custom.properties | tr -d ' ')

--- a/Dockerfiles/presentation/assets/scripts/mysql.sh
+++ b/Dockerfiles/presentation/assets/scripts/mysql.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright 2016 The WWU eLectures Team All rights reserved.
 #
@@ -16,15 +16,15 @@
 
 set -e
 
-Opencast::MySQL::Check() {
-  echo "Run Opencast::MySQL::Check"
-  ORG_OPENCASTPROJECT_DB_JDBC_DRIVER="com.mysql.jdbc.Driver"
+opencast_mysql_check() {
+  echo "Run opencast_mysql_check"
+  export ORG_OPENCASTPROJECT_DB_JDBC_DRIVER="com.mysql.jdbc.Driver"
 }
 
-Opencast::MySQL::Configure() {
-  echo "Run Opencast::MySQL::Configure"
+opencast_mysql_configure() {
+  echo "Run opencast_mysql_configure"
 }
 
-Opencast::MySQL::PrintDDL() {
+opencast_mysql_printddl() {
   cat /opencast/docs/scripts/ddl/mysql5.sql
 }

--- a/Dockerfiles/presentation/assets/scripts/opencast.sh
+++ b/Dockerfiles/presentation/assets/scripts/opencast.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright 2016 The WWU eLectures Team All rights reserved.
 #
@@ -19,15 +19,17 @@ set -e
 ORG_OPENCASTPROJECT_ADMIN_EMAIL="${ORG_OPENCASTPROJECT_ADMIN_EMAIL:-admin@localhost}"
 ORG_OPENCASTPROJECT_DOWNLOAD_URL="${ORG_OPENCASTPROJECT_DOWNLOAD_URL:-\$\{org.opencastproject.server.url\}/static}"
 
-if Opencast::Helper::Dist::allinone; then
-  ORG_OPENCASTPROJECT_FILE_REPO_URL='${org.opencastproject.server.url}'
+if opencast_helper_dist_allinone; then
+  # shellcheck disable=SC2016
+  export ORG_OPENCASTPROJECT_FILE_REPO_URL='${org.opencastproject.server.url}'
 else
-  ORG_OPENCASTPROJECT_FILE_REPO_URL='${org.opencastproject.admin.ui.url}'
+  # shellcheck disable=SC2016
+  export ORG_OPENCASTPROJECT_FILE_REPO_URL='${org.opencastproject.admin.ui.url}'
 fi
 
-Opencast::Opencast::Check() {
-  echo "Run Opencast::Opencast::Check"
-  Opencast::Helper::CheckForVariables \
+opencast_opencast_check() {
+  echo "Run opencast_opencast_check"
+  opencast_helper_checkforvariables \
     "ORG_OPENCASTPROJECT_SERVER_URL" \
     "ORG_OPENCASTPROJECT_SECURITY_ADMIN_USER" \
     "ORG_OPENCASTPROJECT_SECURITY_ADMIN_PASS" \
@@ -35,16 +37,16 @@ Opencast::Opencast::Check() {
     "ORG_OPENCASTPROJECT_SECURITY_DIGEST_PASS" \
     "ORG_OPENCASTPROJECT_FILE_REPO_URL"
 
-  if ! Opencast::Helper::Dist::allinone; then
-    Opencast::Helper::CheckForVariables \
+  if ! opencast_helper_dist_allinone; then
+    opencast_helper_checkforvariables \
       "PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL" \
       "PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL"
   fi
 }
 
-Opencast::Opencast::Configure() {
-  echo "Run Opencast::Opencast::Configure"
-  Opencast::Helper::ReplaceInfile "etc/custom.properties" \
+opencast_opencast_configure() {
+  echo "Run opencast_opencast_configure"
+  opencast_helper_replaceinfile "etc/custom.properties" \
     "ORG_OPENCASTPROJECT_ADMIN_EMAIL" \
     "ORG_OPENCASTPROJECT_SERVER_URL" \
     "ORG_OPENCASTPROJECT_SECURITY_ADMIN_USER" \
@@ -54,8 +56,8 @@ Opencast::Opencast::Configure() {
     "ORG_OPENCASTPROJECT_FILE_REPO_URL" \
     "ORG_OPENCASTPROJECT_DOWNLOAD_URL"
 
-  if ! Opencast::Helper::Dist::allinone; then
-    Opencast::Helper::ReplaceInfile "etc/org.opencastproject.organization-mh_default_org.cfg" \
+  if ! opencast_helper_dist_allinone; then
+    opencast_helper_replaceinfile "etc/org.opencastproject.organization-mh_default_org.cfg" \
       "PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL" \
       "PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL"
   fi

--- a/Dockerfiles/worker/Dockerfile
+++ b/Dockerfiles/worker/Dockerfile
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM maven:3-jdk-8
-MAINTAINER WWU eLectures team <dev.learnweb@uni-muenster.de>
+FROM java:8-jdk-alpine
+MAINTAINER WWU eLectures team <electures.dev@uni-muenster.de>
 
 ENV OPENCAST_VERSION="2.1.1" \
     OPENCAST_DISTRIBUTION="worker" \
@@ -24,46 +24,133 @@ ENV OPENCAST_VERSION="2.1.1" \
     OPENCAST_USER="opencast" \
     OPENCAST_GROUP="opencast" \
     OPENCAST_UID="800" \
-    OPENCAST_GID="800"
+    OPENCAST_GID="800" \
+    \
+    TESSERACT_BASE_URL="https://github.com/tesseract-ocr/tessdata/raw/master" \
+    HUNSPELL_BASE_URL="http://download.services.openoffice.org/contrib/dictionaries" \
+    TESSERACT_LANG="\
+cb7eb42a7e972cec7ef904fe81825d7b547c46df684c814fdb11a930b13bca3a deu.traineddata\n\
+64adf2cc0b2a6705368aa357224d1a6739035d5fe892cd0cc457016df5b4280f eng.cube.bigrams\n\
+2b229895623934b493fe69c51fcc387295d91af8b4e43cc51748b3d269a95eed eng.cube.fold\n\
+a6f769245b0a55f42a3ce157cd19d96828483c3384c6483433ed83579ea16e36 eng.cube.lm\n\
+8f345f1c19772dd71a5214bc94175ccf647c003ab77e4143fde48f11bf3cb0ef eng.cube.nn\n\
+c2aa2854951bd823d89cc86d53a6d9712a6a885de6fbaf650ff3df48bfed85d7 eng.cube.params\n\
+e5f95de7e2754eb2df03451885277ca4573b3770816043ae2e2f09d1f7232604 eng.cube.size\n\
+8d612bef20ae3052fce0b8650575a80d87c94d772ec6d1f0c6a1ad591586ea44 eng.cube.word-freq\n\
+196bedc8a5bc8c30361c2c9518f648b45b498759cb6041827ff6fbfb8da2a8d1 eng.tesseract_cube.nn\n\
+c0515c9f1e0c79e1069fcc05c2b2f6a6841fb5e1082d695db160333c1154f06d eng.traineddata\
+    " \
+    HUNSPELL_LANG="\
+2478723ab67dd801ec6add11b1af9d32665e7859a1cb00c95bfc2b618584a802 de_AT.zip\n\
+c30bb085ba0a3d22a23aef51f4dd94ae9ae0cc811c0590ebf3713a93b209d823 de_CH.zip\n\
+220e01c3137000305247336d8d10cd550bda3990fb10e50b31633947969a34b8 de_DE_comb.zip\n\
+22e217a631977d7b377f8dd22d2bbacd2d36b32765ce13f3474b03a4a97dd700 en_AU.zip\n\
+31fac12a1b520cde686f328d3fa7560f6eba772cddc872197ff842c57a0dc1ea en_CA.zip\n\
+5869d8bd80eb2eb328ebe36b356348de4ae2acb1db6df39d1717d33f89f63728 en_GB.zip\n\
+6cc717b4de43240595662a2deef5447b06062e82380f5647196f07c9089284fa en_NZ.zip\n\
+9227f658f182c9cece797352f041a888134765c11bffc91951c010a73187baea en_US.zip\n\
+090285b721dcaabff51b467123f82a181a6904d187c90bda812c6e5f365ff19a en_ZA.zip\
+    "
 ENV OPENCAST_SCRIPTS="${OPENCAST_HOME}/docker/scripts" \
     OPENCAST_CONFIG="${OPENCAST_HOME}/etc" \
-    OPENCAST_URL="https://bitbucket.org/opencast-community/matterhorn/get/${OPENCAST_VERSION}.tar.bz2"
+    OPENCAST_URL="https://bitbucket.org/opencast-community/matterhorn/get/${OPENCAST_VERSION}.tar.gz"
 
-# Dependencies
-#   - cURL and bzip2
-#   - FFmpeg
-#   - MediaInfo
-#   - Sound eXchange (SoX)
-#   - Tesseract Open Source OCR Engine
-#   -   - english
-#   -   - german
-#   - TODO: which languages to include?
-#   - Hunspell
-#   -   - english
-#   -   - german
-#   - TODO: which languages to include?
-RUN apt-get update \
- && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      curl bzip2 \
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
+ && apk add --no-cache --virtual .build-deps \
+      tar gzip \
+      git \
+      make gcc g++ binutils-gold \
+      maven \
+      python \
+      nodejs \
+      \
+      # TODO: for tesseract; remove once package is updated
+      automake autoconf libtool \
+  \
+  # Install dependencies
+  #   - FFmpeg
+  #   - Sound eXchange (SoX)
+  #   - Tesseract Open Source OCR Engine
+  #   - Hunspell
+ && apk add --no-cache --virtual .run-deps \
       ffmpeg \
-      mediainfo \
-      sox libsox-fmt-all \
-      tesseract-ocr tesseract-ocr-eng tesseract-ocr-deu \
-      hunspell hunspell-en-us hunspell-de-de \
- && rm -rf /var/lib/apt/lists/*
-
-# Opencast
-RUN mkdir -p "${OPENCAST_SRC}" "${OPENCAST_HOME}" "${OPENCAST_DATA}" "${OPENCAST_SCRIPTS}" \
- && groupadd -r "${OPENCAST_GROUP}" -g "${OPENCAST_GID}" \
- && useradd -r -g "${OPENCAST_GROUP}" -d "${OPENCAST_HOME}" -u "${OPENCAST_UID}" "${OPENCAST_USER}" \
- && chown "${OPENCAST_USER}":"${OPENCAST_GROUP}" "${OPENCAST_SRC}" "${OPENCAST_HOME}" "${OPENCAST_DATA}"
-
-RUN cd "${OPENCAST_SRC}" \
- && curl -sSL "${OPENCAST_URL}" | tar -xj --strip 1 -C . \
- && mvn --quiet --batch-mode clean install -DskipTests=true -Dcheckstyle.skip=true \
- && tar -xzf "build/opencast-dist-${OPENCAST_DISTRIBUTION}-${OPENCAST_VERSION}.tar.gz" --strip 1 -C "${OPENCAST_HOME}" \
- && chown -R "${OPENCAST_USER}":"${OPENCAST_GROUP}" "${OPENCAST_HOME}" \
- && rm -rf "${OPENCAST_SRC}" /tmp/* ~/.npm ~/.node-gyp
+      sox \
+      hunspell \
+      \
+      # TODO: for tesseract; remove once package is updated
+      libjpeg-turbo-dev tiff-dev libpng-dev zlib-dev giflib-dev libwebp-dev \
+  \
+  # TODO: compile tesseract; remove once package is updated
+ && LEPTONICA_VERSION=1.73 \
+ && TESSERACT_VERSION=3.04.01 \
+ && mkdir -p /tmp/compile/leptonica /tmp/compile/tesseract \
+ && cd /tmp/compile \
+ && wget -q -O - "http://www.leptonica.com/source/leptonica-${LEPTONICA_VERSION}.tar.gz" | tar -xz --strip 1 -C leptonica \
+ && wget -q -O - "https://github.com/tesseract-ocr/tesseract/archive/${TESSERACT_VERSION}.tar.gz" | tar -xz --strip 1 -C tesseract \
+ && cd leptonica \
+ && ./configure \
+     --prefix=/usr \
+     --sysconfdir=/etc \
+     --mandir=/usr/share/man \
+     --infodir=/usr/share/info \
+     --localstatedir=/var \
+ && make \
+ && make install \
+ && cd ../tesseract/ \
+ && ./autogen.sh \
+ && ./configure \
+   --prefix=/usr \
+   --sysconfdir=/etc \
+   --mandir=/usr/share/man \
+   --infodir=/usr/share/info \
+   --localstatedir=/var \
+   --disable-static \
+   --disable-graphics \
+ && make \
+ && make install \
+  \
+  # Install languag files for tesseract and hunspell
+ && mkdir -p /tmp/tesseract /tmp/hunspell /usr/share/hunspell /usr/share/tesseract \
+ && echo -e ${TESSERACT_LANG} > /tmp/tesseract-sha256sum.txt \
+ && echo -e ${HUNSPELL_LANG} > /tmp/hunspell-sha256sum.txt \
+  \
+  # TODO: How to output with two spaces?
+ && sed -i "s/ /  /g" /tmp/tesseract-sha256sum.txt /tmp/hunspell-sha256sum.txt \
+ && cd /tmp/tesseract \
+ && for file in $(awk '{print $2}' /tmp/tesseract-sha256sum.txt); do \
+      wget -O "${file}" "${TESSERACT_BASE_URL}/${file}"; \
+      grep "${file}" /tmp/tesseract-sha256sum.txt | sha256sum -c -; \
+      cp "${file}" /usr/share/tesseract; \
+    done \
+ && cd /tmp/hunspell \
+ && for file in $(awk '{print $2}' /tmp/hunspell-sha256sum.txt); do \
+      wget -O "${file}" "${HUNSPELL_BASE_URL}/${file}"; \
+      grep "${file}" /tmp/hunspell-sha256sum.txt | sha256sum -c -; \
+      unzip "/tmp/hunspell/${file}"; \
+    done \
+ && cp *.aff *.dic /usr/share/hunspell \
+  \
+  # Compile frontend assets manually as the bundeled node does not run on Alpine
+ && mkdir -p "${OPENCAST_SRC}" "${OPENCAST_HOME}" "${OPENCAST_DATA}" "${OPENCAST_SCRIPTS}" \
+ && wget -O - "${OPENCAST_URL}" | tar -xz --strip 1 -C "${OPENCAST_SRC}" \
+ && cd "${OPENCAST_SRC}/modules/matterhorn-admin-ui-ng" \
+ && sed -i 's/"grunt-sass":.*/"grunt-sass": "^1.2.0",/g' package.json \
+ && npm install -g npm@2 \
+ && npm install -g grunt \
+ && npm install \
+ && grunt build --no-color --skipTests=true \
+  \
+  # Compile and install Opencast
+ && cd "${OPENCAST_SRC}" \
+ && mvn --quiet --batch-mode install -P '!frontend' -DskipTests=true -Dcheckstyle.skip=true \
+ && tar -xzf build/opencast-dist-${OPENCAST_DISTRIBUTION}-*.tar.gz --strip 1 -C "${OPENCAST_HOME}" \
+ && addgroup -S -g "${OPENCAST_GID}" "${OPENCAST_GROUP}" \
+ && adduser -S -D -H -G "${OPENCAST_GROUP}" -h "${OPENCAST_HOME}" -u "${OPENCAST_UID}" "${OPENCAST_USER}" \
+ && chown -R "${OPENCAST_USER}":"${OPENCAST_GROUP}" "${OPENCAST_HOME}" "${OPENCAST_DATA}" \
+  \
+  # Cleanup
+ && apk del .build-deps \
+ && rm -rf "${OPENCAST_SRC}" /tmp/* ~/.m2 ~/.npm ~/.node-gyp /usr/lib/node_modules
 
 COPY assets/scripts/* "${OPENCAST_SCRIPTS}/"
 COPY assets/etc/* "${OPENCAST_CONFIG}/"

--- a/Dockerfiles/worker/assets/docker-entrypoint.sh
+++ b/Dockerfiles/worker/assets/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright 2016 The WWU eLectures Team All rights reserved.
 #
@@ -16,63 +16,71 @@
 
 set -e
 
-source "${OPENCAST_SCRIPTS}/helper.sh"
-source "${OPENCAST_SCRIPTS}/opencast.sh"
-source "${OPENCAST_SCRIPTS}/activemq.sh"
-source "${OPENCAST_SCRIPTS}/db.sh"
-source "${OPENCAST_SCRIPTS}/hsql.sh"
-source "${OPENCAST_SCRIPTS}/jdbc.sh"
-source "${OPENCAST_SCRIPTS}/mysql.sh"
+# shellcheck source=./scripts/helper.sh
+. "${OPENCAST_SCRIPTS}/helper.sh"
+# shellcheck source=./scripts/opencast.sh
+. "${OPENCAST_SCRIPTS}/opencast.sh"
+# shellcheck source=./scripts/activemq.sh
+. "${OPENCAST_SCRIPTS}/activemq.sh"
+# shellcheck source=./scripts/db.sh
+. "${OPENCAST_SCRIPTS}/db.sh"
+# shellcheck source=./scripts/hsql.sh
+. "${OPENCAST_SCRIPTS}/hsql.sh"
+# shellcheck source=./scripts/jdbc.sh
+. "${OPENCAST_SCRIPTS}/jdbc.sh"
+# shellcheck source=./scripts/mysql.sh
+. "${OPENCAST_SCRIPTS}/mysql.sh"
 
-Opencast::Main::Check() {
-  echo "Run Opencast::Main::Check"
 
-  Opencast::Opencast::Check
-  Opencast::ActiveMQ::Check
-  Opencast::DB::Check
+opencast_main_check() {
+  echo "Run opencast_main_check"
+
+  opencast_opencast_check
+  opencast_activemq_check
+  opencast_db_check
 }
 
-Opencast::Main::Configure() {
-  echo "Run Opencast::Main::Configure"
+opencast_main_configure() {
+  echo "Run opencast_main_configure"
 
-  Opencast::Opencast::Configure
-  Opencast::ActiveMQ::Configure
-  Opencast::DB::Configure
+  opencast_opencast_configure
+  opencast_activemq_configure
+  opencast_db_configure
 }
 
-Opencast::Main::Init() {
-  echo "Run Opencast::Main::Init"
+opencast_main_init() {
+  echo "Run opencast_main_init"
 
-  if Opencast::Helper::CustomConfig; then
+  if opencast_helper_customconfig; then
     echo "Found custom config in ${OPENCAST_CUSTOM_CONFIG}"
-    echo "Run Opencast::Helper::CopyCustomConfig"
-    Opencast::Helper::CopyCustomConfig
+    echo "Run opencast_helper_copycustomconfig"
+    opencast_helper_copycustomconfig
   else
     echo "No custom config found"
-    Opencast::Main::Check
-    Opencast::Main::Configure
+    opencast_main_check
+    opencast_main_configure
   fi
 }
 
-Opencast::Main::Start() {
-  echo "Run Opencast::Main::Start"
+opencast_main_start() {
+  echo "Run opencast_main_start"
   exec "bin/start-opencast" "server"
 }
 
 case ${1} in
   app:init)
-    Opencast::Main::Init
+    opencast_main_init
     ;;
   app:start)
-    Opencast::Main::Init
-    Opencast::DB::TryToConnect
-    Opencast::Main::Start
+    opencast_main_init
+    opencast_db_trytoconnect
+    opencast_main_start
     ;;
   app:print:activemq.xml)
-    Opencast::ActiveMQ::PrintActivemq.xml
+    opencast_activemq_printactivemqxml
     ;;
   app:print:dll)
-    Opencast::DB::PrintDDL
+    opencast_db_print_ddl
     ;;
   app:help)
     echo "Usage:"

--- a/Dockerfiles/worker/assets/scripts/activemq.sh
+++ b/Dockerfiles/worker/assets/scripts/activemq.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright 2016 The WWU eLectures Team All rights reserved.
 #
@@ -16,25 +16,25 @@
 
 set -e
 
-Opencast::ActiveMQ::Check() {
-  echo "Run Opencast::ActiveMQ::Check"
+opencast_activemq_check() {
+  echo "Run opencast_activemq_check"
 
-  Opencast::Helper::CheckForVariables \
+  opencast_helper_checkforvariables \
     "ACTIVEMQ_BROKER_URL" \
     "ACTIVEMQ_BROKER_USERNAME" \
     "ACTIVEMQ_BROKER_PASSWORD"
 }
 
-Opencast::ActiveMQ::Configure() {
-  echo "Run Opencast::ActiveMQ::Configure"
+opencast_activemq_configure() {
+  echo "Run opencast_activemq_configure"
 
-  Opencast::Helper::ReplaceInfile "etc/custom.properties" \
+  opencast_helper_replaceinfile "etc/custom.properties" \
     "ACTIVEMQ_BROKER_URL" \
     "ACTIVEMQ_BROKER_USERNAME" \
     "ACTIVEMQ_BROKER_PASSWORD"
 }
 
-Opencast::ActiveMQ::PrintActivemq.xml() {
+opencast_activemq_printactivemqxml() {
   # TODO: read env variables and add config for jaasAuthenticationPlugin
   cat /opencast/docs/scripts/activemq/activemq.xml
 }

--- a/Dockerfiles/worker/assets/scripts/db.sh
+++ b/Dockerfiles/worker/assets/scripts/db.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright 2016 The WWU eLectures Team All rights reserved.
 #
@@ -19,16 +19,16 @@ set -e
 ORG_OPENCASTPROJECT_DB_VENDOR="${ORG_OPENCASTPROJECT_DB_VENDOR:-HSQL}"
 NUMER_OF_TIMES_TRYING_TO_CONNECT_TO_DB="${NUMER_OF_TIMES_TRYING_TO_CONNECT_TO_DB:-25}"
 
-Opencast::DB::Check() {
-  echo "Run Opencast::DB::Check"
+opencast_db_check() {
+  echo "Run opencast_db_check"
 
   case "$ORG_OPENCASTPROJECT_DB_VENDOR" in
     HSQL)
-      Opencast::HSQL::Check
+      opencast_hsql_check
       ;;
     MySQL)
-      Opencast::MySQL::Check
-      Opencast::JDBC::Check
+      opencast_mysql_check
+      opencast_jdbc_check
       ;;
     *)
       echo >&2 "error: ${ORG_OPENCASTPROJECT_DB_VENDOR} is currently not supported as database vendor"
@@ -37,16 +37,16 @@ Opencast::DB::Check() {
   esac
 }
 
-Opencast::DB::Configure() {
-  echo "Run Opencast::DB::Configure"
+opencast_db_configure() {
+  echo "Run opencast_db_configure"
 
   case "$ORG_OPENCASTPROJECT_DB_VENDOR" in
     HSQL)
-      Opencast::HSQL::Configure
+      opencast_hsql_configure
       ;;
     MySQL)
-      Opencast::MySQL::Configure
-      Opencast::JDBC::Configure
+      opencast_mysql_configure
+      opencast_jdbc_configure
       ;;
     *)
       echo >&2 "error: ${ORG_OPENCASTPROJECT_DB_VENDOR} is currently not supported as database vendor"
@@ -55,15 +55,15 @@ Opencast::DB::Configure() {
   esac
 }
 
-Opencast::DB::TryToConnect() {
-  echo "Run Opencast::DB::TryToConnect"
+opencast_db_trytoconnect() {
+  echo "Run opencast_db_trytoconnect"
 
   case "$ORG_OPENCASTPROJECT_DB_VENDOR" in
     HSQL)
-      Opencast::HSQL::TryToConnect
+      opencast_hsql_trytoconnect
       ;;
     MySQL)
-      Opencast::JDBC::TryToConnect
+      opencast_jdbc_trytoconnect
       ;;
     *)
       echo >&2 "error: ${ORG_OPENCASTPROJECT_DB_VENDOR} is currently not supported as database vendor"
@@ -72,15 +72,15 @@ Opencast::DB::TryToConnect() {
   esac
 }
 
-Opencast::DB::PrintDDL() {
+opencast_db_printddl() {
   echo "-- Created with Opencast version ${OPENCAST_VERSION}"
   echo
   case "$ORG_OPENCASTPROJECT_DB_VENDOR" in
     HSQL)
-      Opencast::HSQL::PrintDDL
+      opencast_hsql_printddl
       ;;
     MySQL)
-      Opencast::MySQL::PrintDDL
+      opencast_mysql_printddl
       ;;
     *)
       echo >&2 "error: ${ORG_OPENCASTPROJECT_DB_VENDOR} is currently not supported as database vendor"

--- a/Dockerfiles/worker/assets/scripts/helper.sh
+++ b/Dockerfiles/worker/assets/scripts/helper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright 2016 The WWU eLectures Team All rights reserved.
 #
@@ -16,34 +16,36 @@
 
 set -e
 
-Opencast::Helper::Dist::admin() {
+opencast_helper_dist_admin() {
   test "${OPENCAST_DISTRIBUTION}" = "admin"
 }
 
-Opencast::Helper::Dist::allinone() {
+opencast_helper_dist_allinone() {
   test "${OPENCAST_DISTRIBUTION}" = "allinone"
 }
 
-Opencast::Helper::Dist::presentation() {
+opencast_helper_dist_presentation() {
   test "${OPENCAST_DISTRIBUTION}" = "presentation"
 }
 
-Opencast::Helper::Dist::worker() {
+opencast_helper_dist_worker() {
   test "${OPENCAST_DISTRIBUTION}" = "worker"
 }
 
-Opencast::Helper::CustomConfig() {
+opencast_helper_customconfig() {
   test -d "${OPENCAST_CUSTOM_CONFIG}"
 }
 
-Opencast::Helper::CopyCustomConfig() {
+opencast_helper_copycustomconfig() {
   rm -rf "${OPENCAST_CONFIG}"
   cp -r "${OPENCAST_CUSTOM_CONFIG}" "${OPENCAST_CONFIG}"
 }
 
-Opencast::Helper::CheckForVariables() {
+opencast_helper_checkforvariables() {
   for var in "$@"; do
-    if test -z "${!var}"; then
+    eval exp_var="\$${var}"
+    # shellcheck disable=SC2154
+    if test -z "${exp_var}"; then
       echo >&2 "error: missing Opencast ${var} environment variables"
       echo >&2 "  Did you forget to -e ${var}=value ?"
       exit 1
@@ -52,17 +54,18 @@ Opencast::Helper::CheckForVariables() {
 }
 
 # Replaces {{$2...}} with $!2... in file $1
-Opencast::Helper::ReplaceInfile() {
-  local file="$1"
+opencast_helper_replaceinfile() {
+  file="$1"
   shift
   for var in "$@"; do
-    sed -ri "s/[{]{2}${var}[}]{2}/$( echo ${!var} | sed -e 's/[\/&]/\\&/g' )/g" "${file}"
+    eval exp_var="\$${var}"
+    sed -ri "s/[{]{2}${var}[}]{2}/$( echo ${exp_var} | sed -e 's/[\/&]/\\&/g' )/g" "${file}"
   done
 }
 
 # Deletes lines containing {{$2...}} in file $1
-Opencast::Helper::DeleteInfile() {
-  local file="$1"
+opencast_helper_deleteinfile() {
+  file="$1"
   shift
   for var in "$@"; do
     sed -ri "/[{]{2}${var}[}]{2}/d" "${file}"

--- a/Dockerfiles/worker/assets/scripts/hsql.sh
+++ b/Dockerfiles/worker/assets/scripts/hsql.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright 2016 The WWU eLectures Team All rights reserved.
 #
@@ -16,30 +16,30 @@
 
 set -e
 
-Opencast::HSQL::Check() {
-  echo "Run Opencast::HSQL::Check"
+opencast_hsql_check() {
+  echo "Run opencast_hsql_check"
 
-  ORG_OPENCASTPROJECT_DB_DDL_GENERATION="true"
+  export ORG_OPENCASTPROJECT_DB_DDL_GENERATION="true"
 }
 
-Opencast::HSQL::Configure() {
-  echo "Run Opencast::HSQL::Configure"
+opencast_hsql_configure() {
+  echo "Run opencast_hsql_configure"
 
-  Opencast::Helper::DeleteInfile "etc/custom.properties" \
+  opencast_helper_deleteinfile "etc/custom.properties" \
     "ORG_OPENCASTPROJECT_DB_VENDOR" \
     "ORG_OPENCASTPROJECT_DB_JDBC_DRIVER" \
     "ORG_OPENCASTPROJECT_DB_JDBC_URL" \
     "ORG_OPENCASTPROJECT_DB_JDBC_USER" \
     "ORG_OPENCASTPROJECT_DB_JDBC_PASS"
 
-  Opencast::Helper::ReplaceInfile "etc/custom.properties" \
+  opencast_helper_replaceinfile "etc/custom.properties" \
     "ORG_OPENCASTPROJECT_DB_DDL_GENERATION"
 }
 
-Opencast::HSQL::TryToConnect() {
-  echo "Run Opencast::HSQL::TryToConnect"
+opencast_hsql_trytoconnect() {
+  echo "Run opencast_hsql_trytoconnect"
 }
 
-Opencast::HSQL::PrintDDL() {
+opencast_hsql_printddl() {
   echo "-- Database for HSQL is created automatically"
 }

--- a/Dockerfiles/worker/assets/scripts/jdbc.sh
+++ b/Dockerfiles/worker/assets/scripts/jdbc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright 2016 The WWU eLectures Team All rights reserved.
 #
@@ -16,12 +16,12 @@
 
 set -e
 
-Opencast::JDBC::Check() {
-  echo "Run Opencast::JDBC::Check"
+opencast_jdbc_check() {
+  echo "Run opencast_jdbc_check"
 
   ORG_OPENCASTPROJECT_DB_DDL_GENERATION="${ORG_OPENCASTPROJECT_DB_DDL_GENERATION:-false}"
 
-  Opencast::Helper::CheckForVariables \
+  opencast_helper_checkforvariables \
     "ORG_OPENCASTPROJECT_DB_DDL_GENERATION" \
     "ORG_OPENCASTPROJECT_DB_JDBC_DRIVER" \
     "ORG_OPENCASTPROJECT_DB_JDBC_URL" \
@@ -29,10 +29,10 @@ Opencast::JDBC::Check() {
     "ORG_OPENCASTPROJECT_DB_JDBC_PASS"
 }
 
-Opencast::JDBC::Configure() {
-  echo "Run Opencast::JDBC::Configure"
+opencast_jdbc_configure() {
+  echo "Run opencast_jdbc_configure"
 
-  Opencast::Helper::ReplaceInfile "etc/custom.properties" \
+  opencast_helper_replaceinfile "etc/custom.properties" \
     "ORG_OPENCASTPROJECT_DB_VENDOR" \
     "ORG_OPENCASTPROJECT_DB_DDL_GENERATION" \
     "ORG_OPENCASTPROJECT_DB_JDBC_DRIVER" \
@@ -41,8 +41,8 @@ Opencast::JDBC::Configure() {
     "ORG_OPENCASTPROJECT_DB_JDBC_PASS"
 }
 
-Opencast::JDBC::TryToConnect() {
-  echo "Run Opencast::JDBC::TryToConnect"
+opencast_jdbc_trytoconnect() {
+  echo "Run opencast_jdbc_trytoconnect"
 
   driver=$(awk -F "=" '/org\.opencastproject\.db\.jdbc\.driver/ {print $2}' etc/custom.properties | tr -d ' ')
   url=$(awk -F "=" '/org\.opencastproject\.db\.jdbc\.url/ {print $2}' etc/custom.properties | tr -d ' ')

--- a/Dockerfiles/worker/assets/scripts/mysql.sh
+++ b/Dockerfiles/worker/assets/scripts/mysql.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright 2016 The WWU eLectures Team All rights reserved.
 #
@@ -16,15 +16,15 @@
 
 set -e
 
-Opencast::MySQL::Check() {
-  echo "Run Opencast::MySQL::Check"
-  ORG_OPENCASTPROJECT_DB_JDBC_DRIVER="com.mysql.jdbc.Driver"
+opencast_mysql_check() {
+  echo "Run opencast_mysql_check"
+  export ORG_OPENCASTPROJECT_DB_JDBC_DRIVER="com.mysql.jdbc.Driver"
 }
 
-Opencast::MySQL::Configure() {
-  echo "Run Opencast::MySQL::Configure"
+opencast_mysql_configure() {
+  echo "Run opencast_mysql_configure"
 }
 
-Opencast::MySQL::PrintDDL() {
+opencast_mysql_printddl() {
   cat /opencast/docs/scripts/ddl/mysql5.sql
 }

--- a/Dockerfiles/worker/assets/scripts/opencast.sh
+++ b/Dockerfiles/worker/assets/scripts/opencast.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright 2016 The WWU eLectures Team All rights reserved.
 #
@@ -19,15 +19,17 @@ set -e
 ORG_OPENCASTPROJECT_ADMIN_EMAIL="${ORG_OPENCASTPROJECT_ADMIN_EMAIL:-admin@localhost}"
 ORG_OPENCASTPROJECT_DOWNLOAD_URL="${ORG_OPENCASTPROJECT_DOWNLOAD_URL:-\$\{org.opencastproject.server.url\}/static}"
 
-if Opencast::Helper::Dist::allinone; then
-  ORG_OPENCASTPROJECT_FILE_REPO_URL='${org.opencastproject.server.url}'
+if opencast_helper_dist_allinone; then
+  # shellcheck disable=SC2016
+  export ORG_OPENCASTPROJECT_FILE_REPO_URL='${org.opencastproject.server.url}'
 else
-  ORG_OPENCASTPROJECT_FILE_REPO_URL='${org.opencastproject.admin.ui.url}'
+  # shellcheck disable=SC2016
+  export ORG_OPENCASTPROJECT_FILE_REPO_URL='${org.opencastproject.admin.ui.url}'
 fi
 
-Opencast::Opencast::Check() {
-  echo "Run Opencast::Opencast::Check"
-  Opencast::Helper::CheckForVariables \
+opencast_opencast_check() {
+  echo "Run opencast_opencast_check"
+  opencast_helper_checkforvariables \
     "ORG_OPENCASTPROJECT_SERVER_URL" \
     "ORG_OPENCASTPROJECT_SECURITY_ADMIN_USER" \
     "ORG_OPENCASTPROJECT_SECURITY_ADMIN_PASS" \
@@ -35,16 +37,16 @@ Opencast::Opencast::Check() {
     "ORG_OPENCASTPROJECT_SECURITY_DIGEST_PASS" \
     "ORG_OPENCASTPROJECT_FILE_REPO_URL"
 
-  if ! Opencast::Helper::Dist::allinone; then
-    Opencast::Helper::CheckForVariables \
+  if ! opencast_helper_dist_allinone; then
+    opencast_helper_checkforvariables \
       "PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL" \
       "PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL"
   fi
 }
 
-Opencast::Opencast::Configure() {
-  echo "Run Opencast::Opencast::Configure"
-  Opencast::Helper::ReplaceInfile "etc/custom.properties" \
+opencast_opencast_configure() {
+  echo "Run opencast_opencast_configure"
+  opencast_helper_replaceinfile "etc/custom.properties" \
     "ORG_OPENCASTPROJECT_ADMIN_EMAIL" \
     "ORG_OPENCASTPROJECT_SERVER_URL" \
     "ORG_OPENCASTPROJECT_SECURITY_ADMIN_USER" \
@@ -54,8 +56,8 @@ Opencast::Opencast::Configure() {
     "ORG_OPENCASTPROJECT_FILE_REPO_URL" \
     "ORG_OPENCASTPROJECT_DOWNLOAD_URL"
 
-  if ! Opencast::Helper::Dist::allinone; then
-    Opencast::Helper::ReplaceInfile "etc/org.opencastproject.organization-mh_default_org.cfg" \
+  if ! opencast_helper_dist_allinone; then
+    opencast_helper_replaceinfile "etc/org.opencastproject.organization-mh_default_org.cfg" \
       "PROP_ORG_OPENCASTPROJECT_ADMIN_UI_URL" \
       "PROP_ORG_OPENCASTPROJECT_ENGAGE_UI_URL"
   fi


### PR DESCRIPTION
Two reasons:

1. `apt-get` is not reliable enough => CI errors
2. way smaller image size

Images are available as `<distribution>-2.1.1-alpine` as long as this PR is not merged.