### PR TITLE
Use tesseract-ocr package instead of compiling it

### DIFF
--- a/Dockerfiles/admin/Dockerfile
+++ b/Dockerfiles/admin/Dockerfile
@@ -39,9 +39,6 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/reposit
       make gcc g++ binutils-gold \
       maven \
       python \
-      \
-      # TODO: for tesseract; remove once package is updated
-      automake autoconf libtool \
   \
   # Install dependencies
   #   - FFmpeg
@@ -59,41 +56,11 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/reposit
       ffmpeg \
       sox \
       hunspell \
-      \
-      # TODO: for tesseract; remove once package is updated
-      libjpeg-turbo-dev tiff-dev libpng-dev zlib-dev giflib-dev libwebp-dev \
+      tesseract-ocr \
   \
   # TODO: Remove @old repo when http://stackoverflow.com/questions/37450473/cssmin-is-giving-me-path-must-be-a-string-received-undefined is fixed
   && apk add --no-cache --repository "@old http://dl-cdn.alpinelinux.org/alpine/v3.3/main" \
       nodejs@old \
-  # TODO: compile tesseract; remove once package is updated
- && LEPTONICA_VERSION=1.73 \
- && TESSERACT_VERSION=3.04.01 \
- && mkdir -p /tmp/compile/leptonica /tmp/compile/tesseract \
- && cd /tmp/compile \
- && wget -q -O - "http://www.leptonica.com/source/leptonica-${LEPTONICA_VERSION}.tar.gz" | tar -xz --strip 1 -C leptonica \
- && wget -q -O - "https://github.com/tesseract-ocr/tesseract/archive/${TESSERACT_VERSION}.tar.gz" | tar -xz --strip 1 -C tesseract \
- && cd leptonica \
- && ./configure \
-      --prefix=/usr \
-      --sysconfdir=/etc \
-      --mandir=/usr/share/man \
-      --infodir=/usr/share/info \
-      --localstatedir=/var \
- && make \
- && make install \
- && cd ../tesseract/ \
- && ./autogen.sh \
- && ./configure \
-      --prefix=/usr \
-      --sysconfdir=/etc \
-      --mandir=/usr/share/man \
-      --infodir=/usr/share/info \
-      --localstatedir=/var \
-      --disable-static \
-      --disable-graphics \
- && make \
- && make install \
   \
   # Install languag files for tesseract and hunspell
  && mkdir -p /tmp/tesseract /tmp/hunspell /usr/share/tessdata /usr/share/hunspell \

--- a/Dockerfiles/adminworker/Dockerfile
+++ b/Dockerfiles/adminworker/Dockerfile
@@ -39,9 +39,6 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/reposit
       make gcc g++ binutils-gold \
       maven \
       python \
-      \
-      # TODO: for tesseract; remove once package is updated
-      automake autoconf libtool \
   \
   # Install dependencies
   #   - FFmpeg
@@ -59,41 +56,11 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/reposit
       ffmpeg \
       sox \
       hunspell \
-      \
-      # TODO: for tesseract; remove once package is updated
-      libjpeg-turbo-dev tiff-dev libpng-dev zlib-dev giflib-dev libwebp-dev \
+      tesseract-ocr \
   \
   # TODO: Remove @old repo when http://stackoverflow.com/questions/37450473/cssmin-is-giving-me-path-must-be-a-string-received-undefined is fixed
   && apk add --no-cache --repository "@old http://dl-cdn.alpinelinux.org/alpine/v3.3/main" \
       nodejs@old \
-  # TODO: compile tesseract; remove once package is updated
- && LEPTONICA_VERSION=1.73 \
- && TESSERACT_VERSION=3.04.01 \
- && mkdir -p /tmp/compile/leptonica /tmp/compile/tesseract \
- && cd /tmp/compile \
- && wget -q -O - "http://www.leptonica.com/source/leptonica-${LEPTONICA_VERSION}.tar.gz" | tar -xz --strip 1 -C leptonica \
- && wget -q -O - "https://github.com/tesseract-ocr/tesseract/archive/${TESSERACT_VERSION}.tar.gz" | tar -xz --strip 1 -C tesseract \
- && cd leptonica \
- && ./configure \
-      --prefix=/usr \
-      --sysconfdir=/etc \
-      --mandir=/usr/share/man \
-      --infodir=/usr/share/info \
-      --localstatedir=/var \
- && make \
- && make install \
- && cd ../tesseract/ \
- && ./autogen.sh \
- && ./configure \
-      --prefix=/usr \
-      --sysconfdir=/etc \
-      --mandir=/usr/share/man \
-      --infodir=/usr/share/info \
-      --localstatedir=/var \
-      --disable-static \
-      --disable-graphics \
- && make \
- && make install \
   \
   # Install languag files for tesseract and hunspell
  && mkdir -p /tmp/tesseract /tmp/hunspell /usr/share/tessdata /usr/share/hunspell \

--- a/Dockerfiles/allinone/Dockerfile
+++ b/Dockerfiles/allinone/Dockerfile
@@ -39,9 +39,6 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/reposit
       make gcc g++ binutils-gold \
       maven \
       python \
-      \
-      # TODO: for tesseract; remove once package is updated
-      automake autoconf libtool \
   \
   # Install dependencies
   #   - FFmpeg
@@ -59,41 +56,11 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/reposit
       ffmpeg \
       sox \
       hunspell \
-      \
-      # TODO: for tesseract; remove once package is updated
-      libjpeg-turbo-dev tiff-dev libpng-dev zlib-dev giflib-dev libwebp-dev \
+      tesseract-ocr \
   \
   # TODO: Remove @old repo when http://stackoverflow.com/questions/37450473/cssmin-is-giving-me-path-must-be-a-string-received-undefined is fixed
   && apk add --no-cache --repository "@old http://dl-cdn.alpinelinux.org/alpine/v3.3/main" \
       nodejs@old \
-  # TODO: compile tesseract; remove once package is updated
- && LEPTONICA_VERSION=1.73 \
- && TESSERACT_VERSION=3.04.01 \
- && mkdir -p /tmp/compile/leptonica /tmp/compile/tesseract \
- && cd /tmp/compile \
- && wget -q -O - "http://www.leptonica.com/source/leptonica-${LEPTONICA_VERSION}.tar.gz" | tar -xz --strip 1 -C leptonica \
- && wget -q -O - "https://github.com/tesseract-ocr/tesseract/archive/${TESSERACT_VERSION}.tar.gz" | tar -xz --strip 1 -C tesseract \
- && cd leptonica \
- && ./configure \
-      --prefix=/usr \
-      --sysconfdir=/etc \
-      --mandir=/usr/share/man \
-      --infodir=/usr/share/info \
-      --localstatedir=/var \
- && make \
- && make install \
- && cd ../tesseract/ \
- && ./autogen.sh \
- && ./configure \
-      --prefix=/usr \
-      --sysconfdir=/etc \
-      --mandir=/usr/share/man \
-      --infodir=/usr/share/info \
-      --localstatedir=/var \
-      --disable-static \
-      --disable-graphics \
- && make \
- && make install \
   \
   # Install languag files for tesseract and hunspell
  && mkdir -p /tmp/tesseract /tmp/hunspell /usr/share/tessdata /usr/share/hunspell \

--- a/Dockerfiles/build/Dockerfile
+++ b/Dockerfiles/build/Dockerfile
@@ -57,7 +57,6 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/reposit
       sox \
       hunspell \
       tesseract-ocr \
-      \
   \
   # TODO: Remove @old repo when http://stackoverflow.com/questions/37450473/cssmin-is-giving-me-path-must-be-a-string-received-undefined is fixed
   && apk add --no-cache --repository "@old http://dl-cdn.alpinelinux.org/alpine/v3.3/main" \

--- a/Dockerfiles/ingest/Dockerfile
+++ b/Dockerfiles/ingest/Dockerfile
@@ -39,9 +39,6 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/reposit
       make gcc g++ binutils-gold \
       maven \
       python \
-      \
-      # TODO: for tesseract; remove once package is updated
-      automake autoconf libtool \
   \
   # Install dependencies
   #   - FFmpeg
@@ -59,41 +56,11 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/reposit
       ffmpeg \
       sox \
       hunspell \
-      \
-      # TODO: for tesseract; remove once package is updated
-      libjpeg-turbo-dev tiff-dev libpng-dev zlib-dev giflib-dev libwebp-dev \
+      tesseract-ocr \
   \
   # TODO: Remove @old repo when http://stackoverflow.com/questions/37450473/cssmin-is-giving-me-path-must-be-a-string-received-undefined is fixed
   && apk add --no-cache --repository "@old http://dl-cdn.alpinelinux.org/alpine/v3.3/main" \
       nodejs@old \
-  # TODO: compile tesseract; remove once package is updated
- && LEPTONICA_VERSION=1.73 \
- && TESSERACT_VERSION=3.04.01 \
- && mkdir -p /tmp/compile/leptonica /tmp/compile/tesseract \
- && cd /tmp/compile \
- && wget -q -O - "http://www.leptonica.com/source/leptonica-${LEPTONICA_VERSION}.tar.gz" | tar -xz --strip 1 -C leptonica \
- && wget -q -O - "https://github.com/tesseract-ocr/tesseract/archive/${TESSERACT_VERSION}.tar.gz" | tar -xz --strip 1 -C tesseract \
- && cd leptonica \
- && ./configure \
-      --prefix=/usr \
-      --sysconfdir=/etc \
-      --mandir=/usr/share/man \
-      --infodir=/usr/share/info \
-      --localstatedir=/var \
- && make \
- && make install \
- && cd ../tesseract/ \
- && ./autogen.sh \
- && ./configure \
-      --prefix=/usr \
-      --sysconfdir=/etc \
-      --mandir=/usr/share/man \
-      --infodir=/usr/share/info \
-      --localstatedir=/var \
-      --disable-static \
-      --disable-graphics \
- && make \
- && make install \
   \
   # Install languag files for tesseract and hunspell
  && mkdir -p /tmp/tesseract /tmp/hunspell /usr/share/tessdata /usr/share/hunspell \

--- a/Dockerfiles/presentation/Dockerfile
+++ b/Dockerfiles/presentation/Dockerfile
@@ -39,9 +39,6 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/reposit
       make gcc g++ binutils-gold \
       maven \
       python \
-      \
-      # TODO: for tesseract; remove once package is updated
-      automake autoconf libtool \
   \
   # Install dependencies
   #   - FFmpeg
@@ -59,41 +56,11 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/reposit
       ffmpeg \
       sox \
       hunspell \
-      \
-      # TODO: for tesseract; remove once package is updated
-      libjpeg-turbo-dev tiff-dev libpng-dev zlib-dev giflib-dev libwebp-dev \
+      tesseract-ocr \
   \
   # TODO: Remove @old repo when http://stackoverflow.com/questions/37450473/cssmin-is-giving-me-path-must-be-a-string-received-undefined is fixed
   && apk add --no-cache --repository "@old http://dl-cdn.alpinelinux.org/alpine/v3.3/main" \
       nodejs@old \
-  # TODO: compile tesseract; remove once package is updated
- && LEPTONICA_VERSION=1.73 \
- && TESSERACT_VERSION=3.04.01 \
- && mkdir -p /tmp/compile/leptonica /tmp/compile/tesseract \
- && cd /tmp/compile \
- && wget -q -O - "http://www.leptonica.com/source/leptonica-${LEPTONICA_VERSION}.tar.gz" | tar -xz --strip 1 -C leptonica \
- && wget -q -O - "https://github.com/tesseract-ocr/tesseract/archive/${TESSERACT_VERSION}.tar.gz" | tar -xz --strip 1 -C tesseract \
- && cd leptonica \
- && ./configure \
-      --prefix=/usr \
-      --sysconfdir=/etc \
-      --mandir=/usr/share/man \
-      --infodir=/usr/share/info \
-      --localstatedir=/var \
- && make \
- && make install \
- && cd ../tesseract/ \
- && ./autogen.sh \
- && ./configure \
-      --prefix=/usr \
-      --sysconfdir=/etc \
-      --mandir=/usr/share/man \
-      --infodir=/usr/share/info \
-      --localstatedir=/var \
-      --disable-static \
-      --disable-graphics \
- && make \
- && make install \
   \
   # Install languag files for tesseract and hunspell
  && mkdir -p /tmp/tesseract /tmp/hunspell /usr/share/tessdata /usr/share/hunspell \

--- a/Dockerfiles/worker/Dockerfile
+++ b/Dockerfiles/worker/Dockerfile
@@ -39,9 +39,6 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/reposit
       make gcc g++ binutils-gold \
       maven \
       python \
-      \
-      # TODO: for tesseract; remove once package is updated
-      automake autoconf libtool \
   \
   # Install dependencies
   #   - FFmpeg
@@ -59,41 +56,11 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/reposit
       ffmpeg \
       sox \
       hunspell \
-      \
-      # TODO: for tesseract; remove once package is updated
-      libjpeg-turbo-dev tiff-dev libpng-dev zlib-dev giflib-dev libwebp-dev \
+      tesseract-ocr \
   \
   # TODO: Remove @old repo when http://stackoverflow.com/questions/37450473/cssmin-is-giving-me-path-must-be-a-string-received-undefined is fixed
   && apk add --no-cache --repository "@old http://dl-cdn.alpinelinux.org/alpine/v3.3/main" \
       nodejs@old \
-  # TODO: compile tesseract; remove once package is updated
- && LEPTONICA_VERSION=1.73 \
- && TESSERACT_VERSION=3.04.01 \
- && mkdir -p /tmp/compile/leptonica /tmp/compile/tesseract \
- && cd /tmp/compile \
- && wget -q -O - "http://www.leptonica.com/source/leptonica-${LEPTONICA_VERSION}.tar.gz" | tar -xz --strip 1 -C leptonica \
- && wget -q -O - "https://github.com/tesseract-ocr/tesseract/archive/${TESSERACT_VERSION}.tar.gz" | tar -xz --strip 1 -C tesseract \
- && cd leptonica \
- && ./configure \
-      --prefix=/usr \
-      --sysconfdir=/etc \
-      --mandir=/usr/share/man \
-      --infodir=/usr/share/info \
-      --localstatedir=/var \
- && make \
- && make install \
- && cd ../tesseract/ \
- && ./autogen.sh \
- && ./configure \
-      --prefix=/usr \
-      --sysconfdir=/etc \
-      --mandir=/usr/share/man \
-      --infodir=/usr/share/info \
-      --localstatedir=/var \
-      --disable-static \
-      --disable-graphics \
- && make \
- && make install \
   \
   # Install languag files for tesseract and hunspell
  && mkdir -p /tmp/tesseract /tmp/hunspell /usr/share/tessdata /usr/share/hunspell \


### PR DESCRIPTION
Alpine new provides a installable tesseract package. Own compilation is now no longer necessary.